### PR TITLE
Add basic screen initialization and cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(vcurses C)
 
-add_library(vcurses src/vcurses.c)
+add_library(vcurses src/vcurses.c src/screen.c)
 
 target_include_directories(vcurses PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 

--- a/include/vcurses.h
+++ b/include/vcurses.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 int vc_init(void);
+void vc_end(void);
 
 #ifdef __cplusplus
 }

--- a/src/screen.c
+++ b/src/screen.c
@@ -1,0 +1,39 @@
+#include "vcurses.h"
+
+#include <termios.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+static struct termios saved_termios;
+static int term_saved = 0;
+
+int vc_init(void)
+{
+    const char *term = getenv("TERM");
+    if (!term || !*term)
+        return -1;
+
+    if (!isatty(STDIN_FILENO))
+        return -1;
+
+    if (tcgetattr(STDIN_FILENO, &saved_termios) < 0)
+        return -1;
+
+    struct termios raw = saved_termios;
+    cfmakeraw(&raw);
+
+    if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw) < 0)
+        return -1;
+
+    term_saved = 1;
+    return 0;
+}
+
+void vc_end(void)
+{
+    if (term_saved) {
+        tcsetattr(STDIN_FILENO, TCSAFLUSH, &saved_termios);
+        term_saved = 0;
+    }
+}
+

--- a/src/vcurses.c
+++ b/src/vcurses.c
@@ -1,5 +1,4 @@
 #include "vcurses.h"
 
-int vc_init(void) {
-    return 0;
-}
+/* Additional library-wide functions will be implemented here. */
+


### PR DESCRIPTION
## Summary
- implement `vc_init` and `vc_end` to manage raw terminal mode
- keep previous terminal settings and restore them on cleanup
- add new `screen.c` to library build
- update public header with `vc_end` declaration

## Testing
- `cmake .. && make`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68541b2960148324a13194e27f485341