### PR TITLE
Implement terminal initialization and restoration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ AR ?= ar
 CFLAGS ?= -Iinclude -Wall -Wextra -fPIC
 BUILD := build
 LIB := libvcurses.a
-SRCS := src/vcurses.c
+SRCS := src/vcurses.c src/curses.c
 OBJS := $(patsubst src/%.c,$(BUILD)/%.o,$(SRCS))
 
 all: $(LIB)

--- a/include/vcurses.h
+++ b/include/vcurses.h
@@ -6,6 +6,8 @@ extern "C" {
 #endif
 
 int vc_init(void);
+int initscr(void);
+int endwin(void);
 
 #ifdef __cplusplus
 }

--- a/src/curses.c
+++ b/src/curses.c
@@ -1,0 +1,49 @@
+#include "vcurses.h"
+#include <termios.h>
+#include <unistd.h>
+#include <signal.h>
+#include <stdlib.h>
+
+static struct termios orig_termios;
+static int term_initialized = 0;
+
+static void restore_terminal(void) {
+    if (term_initialized) {
+        tcsetattr(STDIN_FILENO, TCSANOW, &orig_termios);
+        term_initialized = 0;
+    }
+}
+
+static void handle_signal(int sig) {
+    restore_terminal();
+    signal(sig, SIG_DFL);
+    raise(sig);
+}
+
+int initscr(void) {
+    if (tcgetattr(STDIN_FILENO, &orig_termios) == -1) {
+        return -1;
+    }
+
+    struct termios raw = orig_termios;
+    raw.c_lflag &= ~(ECHO | ICANON);
+    raw.c_cc[VMIN] = 1;
+    raw.c_cc[VTIME] = 0;
+    if (tcsetattr(STDIN_FILENO, TCSANOW, &raw) == -1) {
+        return -1;
+    }
+
+    term_initialized = 1;
+    atexit(restore_terminal);
+
+    signal(SIGINT, handle_signal);
+    signal(SIGTERM, handle_signal);
+    signal(SIGHUP, handle_signal);
+
+    return 0;
+}
+
+int endwin(void) {
+    restore_terminal();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement `initscr` and `endwin` to manage terminal mode
- handle signals to ensure terminal state is restored
- expose new APIs and update build system

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_685421bf3f40832482ce217089c88a21