### PR TITLE
Add basic color support

### DIFF
--- a/demos/color_demo.c
+++ b/demos/color_demo.c
@@ -1,0 +1,26 @@
+#include "curses.h"
+#include <unistd.h>
+
+int main(void) {
+    if (initscr() == NULL) {
+        return 1;
+    }
+
+    start_color();
+    init_pair(1, COLOR_RED, COLOR_BLACK);
+    init_pair(2, COLOR_GREEN, COLOR_BLACK);
+
+    wmove(stdscr, 0, 0);
+    wcolor_set(stdscr, 1, NULL);
+    waddstr(stdscr, "Red text\n");
+
+    wmove(stdscr, 1, 0);
+    wcolor_set(stdscr, 2, NULL);
+    waddstr(stdscr, "Green text\n");
+
+    refresh();
+    sleep(2);
+
+    endwin();
+    return 0;
+}

--- a/include/curses.h
+++ b/include/curses.h
@@ -13,6 +13,7 @@ typedef struct window {
     int cury, curx; /* cursor position */
     struct window *parent; /* parent for subwindows */
     int keypad_mode; /* keypad enabled */
+    int attr; /* current attributes */
 } WINDOW;
 
 extern WINDOW *stdscr;
@@ -53,6 +54,36 @@ int keypad(WINDOW *win, int bf);
 #define KEY_F10    KEY_F(10)
 #define KEY_F11    KEY_F(11)
 #define KEY_F12    KEY_F(12)
+
+/* Color definitions */
+#define COLOR_BLACK   0
+#define COLOR_RED     1
+#define COLOR_GREEN   2
+#define COLOR_YELLOW  3
+#define COLOR_BLUE    4
+#define COLOR_MAGENTA 5
+#define COLOR_CYAN    6
+#define COLOR_WHITE   7
+
+#define COLOR_PAIRS   256
+#define COLOR_PAIR(n)   ((n) << 8)
+#define PAIR_NUMBER(a)  (((a) >> 8) & 0xFF)
+#define A_COLOR       0xFF00
+
+int start_color(void);
+int init_pair(short pair, short fg, short bg);
+
+int attron(int attrs);
+int attroff(int attrs);
+int attrset(int attrs);
+int wattron(WINDOW *win, int attrs);
+int wattroff(WINDOW *win, int attrs);
+int wattrset(WINDOW *win, int attrs);
+int color_set(short pair, void *opts);
+int wcolor_set(WINDOW *win, short pair, void *opts);
+
+/* Internal helper used by the library */
+void _vcurses_apply_attr(int attr);
 
 #ifdef __cplusplus
 }

--- a/src/curses.c
+++ b/src/curses.c
@@ -4,6 +4,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>
+#include <stdio.h>
 
 static struct termios orig_termios;
 static int term_initialized = 0;
@@ -61,6 +62,7 @@ WINDOW *initscr(void) {
     stdscr->curx = 0;
     stdscr->parent = NULL;
     stdscr->keypad_mode = 0;
+    stdscr->attr = COLOR_PAIR(0);
 
     return stdscr;
 }
@@ -185,3 +187,82 @@ int keypad(WINDOW *win, int bf) {
     win->keypad_mode = bf ? 1 : 0;
     return 0;
 }
+
+/* ----- Color and attribute handling ----- */
+
+#define MAX_COLOR_PAIRS COLOR_PAIRS
+
+typedef struct { short fg; short bg; } color_pair_t;
+static color_pair_t color_pairs[MAX_COLOR_PAIRS];
+static int colors_initialized = 0;
+
+int start_color(void) {
+    colors_initialized = 1;
+    color_pairs[0].fg = COLOR_WHITE;
+    color_pairs[0].bg = COLOR_BLACK;
+    return 0;
+}
+
+int init_pair(short pair, short fg, short bg) {
+    if (pair < 0 || pair >= MAX_COLOR_PAIRS)
+        return -1;
+    color_pairs[pair].fg = fg;
+    color_pairs[pair].bg = bg;
+    return 0;
+}
+
+static void apply_attr(int attr) {
+    if (attr & A_COLOR) {
+        short pair = PAIR_NUMBER(attr);
+        if (pair >= 0 && pair < MAX_COLOR_PAIRS && colors_initialized) {
+            short fg = color_pairs[pair].fg;
+            short bg = color_pairs[pair].bg;
+            printf("\x1b[%d;%dm", 30 + fg, 40 + bg);
+            return;
+        }
+    }
+    /* default colors */
+    if (colors_initialized) {
+        printf("\x1b[%d;%dm", 30 + color_pairs[0].fg, 40 + color_pairs[0].bg);
+    }
+}
+
+void _vcurses_apply_attr(int attr) {
+    apply_attr(attr);
+}
+
+int wattron(WINDOW *win, int attrs) {
+    if (!win)
+        return -1;
+    win->attr |= attrs;
+    return 0;
+}
+
+int wattroff(WINDOW *win, int attrs) {
+    if (!win)
+        return -1;
+    win->attr &= ~attrs;
+    return 0;
+}
+
+int wattrset(WINDOW *win, int attrs) {
+    if (!win)
+        return -1;
+    win->attr = attrs;
+    return 0;
+}
+
+int attron(int attrs) { return wattron(stdscr, attrs); }
+int attroff(int attrs) { return wattroff(stdscr, attrs); }
+int attrset(int attrs) { return wattrset(stdscr, attrs); }
+
+int wcolor_set(WINDOW *win, short pair, void *opts) {
+    (void)opts;
+    if (!win)
+        return -1;
+    win->attr &= ~A_COLOR;
+    win->attr |= COLOR_PAIR(pair);
+    return 0;
+}
+
+int color_set(short pair, void *opts) { return wcolor_set(stdscr, pair, opts); }

--- a/src/windows.c
+++ b/src/windows.c
@@ -16,6 +16,7 @@ WINDOW *newwin(int nlines, int ncols, int begin_y, int begin_x) {
     win->curx = 0;
     win->parent = NULL;
     win->keypad_mode = 0;
+    win->attr = COLOR_PAIR(0);
     return win;
 }
 
@@ -63,7 +64,9 @@ int waddstr(WINDOW *win, const char *str) {
     }
     int row = win->begy + win->cury;
     int col = win->begx + win->curx;
-    printf("\x1b[%d;%dH%s", row + 1, col + 1, str);
+    printf("\x1b[%d;%dH", row + 1, col + 1);
+    _vcurses_apply_attr(win->attr);
+    printf("%s", str);
     win->curx += strlen(str);
     return 0;
 }


### PR DESCRIPTION
## Summary
- expand `WINDOW` with attribute storage and color APIs
- implement simple color pair handling in `curses.c`
- apply attributes in `waddstr`
- provide a new `color_demo` showing color usage

## Testing
- `make clean`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_685430dcc13c83249361901d077a7430