### PR TITLE
Add man pages for core API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ artifacts with:
 ```sh
 make clean
 ```
+
+## Documentation
+
+Man pages for the core API are available in `docs/man`. Useful entries
+include [initscr.3](docs/man/initscr.3) and [getch.3](docs/man/getch.3).

--- a/docs/man/getch.3
+++ b/docs/man/getch.3
@@ -1,0 +1,18 @@
+.TH getch 3 "2025-06-19" "vcurses" "vcurses Library"
+.SH NAME
+getch \- read a character from the standard screen
+.SH SYNOPSIS
+.nf
+#include <curses.h>
+.sp
+.BI "int getch(void);"
+.fi
+.SH DESCRIPTION
+The \fBgetch()\fP function reads the next character from \fIstdscr\fP.
+If keypad mode is enabled on \fIstdscr\fP, special keys are returned as
+their predefined KEY_* codes.
+.SH RETURN VALUE
+On success the read character or key code is returned. On error
+-1 is returned.
+.SH SEE ALSO
+wgetch(3), keypad(3), initscr(3)

--- a/docs/man/initscr.3
+++ b/docs/man/initscr.3
@@ -1,0 +1,21 @@
+.TH initscr 3 "2025-06-19" "vcurses" "vcurses Library"
+.SH NAME
+initscr \- initialize the vcurses library
+.SH SYNOPSIS
+.nf
+#include <vcurses.h>
+.sp
+.BI "WINDOW *initscr(void);"
+.fi
+.SH DESCRIPTION
+The \fBinitscr()\fP function initializes the terminal for use with
+vcurses. It switches the terminal into raw mode, disables echoing
+and allocates the global \fIstdscr\fP window structure. Signal
+handlers are installed to restore the terminal on exit and to handle
+window size changes.
+.SH RETURN VALUE
+On success a pointer to the \fIstdscr\fP window is returned. On
+failure \fBinitscr()\fP returns NULL and the terminal state is
+unchanged.
+.SH SEE ALSO
+endwin(3), getch(3)


### PR DESCRIPTION
## Summary
- document `initscr` and `getch` in manual pages
- link man pages from the README

## Testing
- `make`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_6854351bb3dc8324b8fceada590f27f6