### PR TITLE
Add curs_set function

### DIFF
--- a/docs/man/curs_set.3
+++ b/docs/man/curs_set.3
@@ -1,0 +1,19 @@
+.TH curs_set 3 "2025-06-19" "vcurses" "vcurses Library"
+.SH NAME
+curs_set \- control cursor visibility
+.SH SYNOPSIS
+.nf
+#include <curses.h>
+.sp
+.BI "int curs_set(int visibility);"
+.fi
+.SH DESCRIPTION
+The \fBcurs_set()\fP function changes the terminal's cursor visibility.  If
+\fIvisibility\fP is 0 the cursor is hidden, otherwise it is shown.  The
+previous visibility state is returned or -1 if \fIvisibility\fP is
+invalid.
+.SH RETURN VALUE
+On success the previous visibility state is returned.  On error -1 is
+returned.
+.SH SEE ALSO
+initscr(3)

--- a/include/curses.h
+++ b/include/curses.h
@@ -73,6 +73,7 @@ int wattroff(WINDOW *win, int attrs);
 int wattrset(WINDOW *win, int attrs);
 int color_set(short pair, void *opts);
 int wcolor_set(WINDOW *win, short pair, void *opts);
+int curs_set(int visibility);
 
 /* Internal helper used by the library */
 void _vcurses_apply_attr(int attr);

--- a/src/curses.c
+++ b/src/curses.c
@@ -91,3 +91,20 @@ int addstr(const char *str) {
 int addch(char ch) {
     return waddch(stdscr, ch);
 }
+
+static int _cursor_state = 1;
+
+int curs_set(int visibility) {
+    int prev = _cursor_state;
+    if (visibility == 0) {
+        fputs("\x1b[?25l", stdout);
+        _cursor_state = 0;
+    } else if (visibility == 1) {
+        fputs("\x1b[?25h", stdout);
+        _cursor_state = 1;
+    } else {
+        return -1;
+    }
+    fflush(stdout);
+    return prev;
+}


### PR DESCRIPTION
## Summary
- expose `curs_set` in the public API
- implement `curs_set` to hide/show the terminal cursor
- document the new function in a man page

## Testing
- `make test` *(fails: check.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_685473385f4c8324b5447a23459276ad