### PR TITLE
Implement line input helpers

### DIFF
--- a/include/curses.h
+++ b/include/curses.h
@@ -26,6 +26,8 @@ int addstr(const char *str);
 int waddstr(WINDOW *win, const char *str);
 int wgetch(WINDOW *win);
 int getch(void);
+int wgetstr(WINDOW *win, char *str);
+int getstr(char *str);
 int keypad(WINDOW *win, bool yes);
 int nodelay(WINDOW *win, bool bf);
 int wtimeout(WINDOW *win, int delay);

--- a/src/input.c
+++ b/src/input.c
@@ -117,6 +117,27 @@ int getch(void) {
     return wgetch(stdscr);
 }
 
+int wgetstr(WINDOW *win, char *str) {
+    if (!win || !str)
+        return -1;
+
+    int ch;
+    char *p = str;
+
+    while ((ch = wgetch(win)) != -1) {
+        if (ch == '\n' || ch == '\r') {
+            *p = '\0';
+            return 0;
+        }
+        *p++ = (char)ch;
+    }
+    return -1;
+}
+
+int getstr(char *str) {
+    return wgetstr(stdscr, str);
+}
+
 int keypad(WINDOW *win, bool yes) {
     if (!win)
         return -1;


### PR DESCRIPTION
## Summary
- add `wgetstr` and `getstr` prototypes
- implement simple line input helpers that read until newline

## Testing
- `make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685475ed8f9c83249aaf4f3a997e1f80