### PR TITLE
Add color query helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,6 @@ include [initscr.3](docs/man/initscr.3) and [getch.3](docs/man/getch.3).
 enable color handling and define up to 256 color pairs with
 `init_pair(pair, fg, bg)`. The macro `COLOR_PAIR(n)` can then be used with
 `attron`, `attroff`, or `attrset` (or their window variants) to apply a
-defined pair.
+defined pair. Use `pair_content(pair, &fg, &bg)` to query a pair and
+`color_content(color, &r, &g, &b)` to retrieve the RGB components of a
+color.

--- a/include/curses.h
+++ b/include/curses.h
@@ -69,6 +69,8 @@ int box(WINDOW *win, char verch, char horch);
 
 int start_color(void);
 int init_pair(short pair, short fg, short bg);
+int pair_content(short pair, short *fg, short *bg);
+int color_content(short color, short *r, short *g, short *b);
 
 int attron(int attrs);
 int attroff(int attrs);

--- a/src/color.c
+++ b/src/color.c
@@ -1,14 +1,24 @@
 #include "curses.h"
 
 typedef struct { short fg; short bg; } color_pair_t;
+typedef struct { short r; short g; short b; } color_rgb_t;
 
 color_pair_t _vc_color_pairs[COLOR_PAIRS];
 int _vc_colors_initialized = 0;
+static color_rgb_t _vc_colors[8];
 
 int start_color(void) {
     _vc_colors_initialized = 1;
     _vc_color_pairs[0].fg = COLOR_WHITE;
     _vc_color_pairs[0].bg = COLOR_BLACK;
+    _vc_colors[COLOR_BLACK]   = (color_rgb_t){0, 0, 0};
+    _vc_colors[COLOR_RED]     = (color_rgb_t){1000, 0, 0};
+    _vc_colors[COLOR_GREEN]   = (color_rgb_t){0, 1000, 0};
+    _vc_colors[COLOR_YELLOW]  = (color_rgb_t){1000, 1000, 0};
+    _vc_colors[COLOR_BLUE]    = (color_rgb_t){0, 0, 1000};
+    _vc_colors[COLOR_MAGENTA] = (color_rgb_t){1000, 0, 1000};
+    _vc_colors[COLOR_CYAN]    = (color_rgb_t){0, 1000, 1000};
+    _vc_colors[COLOR_WHITE]   = (color_rgb_t){1000, 1000, 1000};
     return 0;
 }
 
@@ -17,5 +27,27 @@ int init_pair(short pair, short fg, short bg) {
         return -1;
     _vc_color_pairs[pair].fg = fg;
     _vc_color_pairs[pair].bg = bg;
+    return 0;
+}
+
+int pair_content(short pair, short *fg, short *bg) {
+    if (!_vc_colors_initialized || pair < 0 || pair >= COLOR_PAIRS)
+        return -1;
+    if (fg)
+        *fg = _vc_color_pairs[pair].fg;
+    if (bg)
+        *bg = _vc_color_pairs[pair].bg;
+    return 0;
+}
+
+int color_content(short color, short *r, short *g, short *b) {
+    if (!_vc_colors_initialized || color < 0 || color > COLOR_WHITE)
+        return -1;
+    if (r)
+        *r = _vc_colors[color].r;
+    if (g)
+        *g = _vc_colors[color].g;
+    if (b)
+        *b = _vc_colors[color].b;
     return 0;
 }

--- a/tests/color.c
+++ b/tests/color.c
@@ -1,0 +1,34 @@
+#include <check.h>
+#include "../include/curses.h"
+
+START_TEST(test_pair_content_returns_values)
+{
+    start_color();
+    init_pair(2, COLOR_GREEN, COLOR_BLUE);
+    short fg=-1, bg=-1;
+    ck_assert_int_eq(pair_content(2, &fg, &bg), 0);
+    ck_assert_int_eq(fg, COLOR_GREEN);
+    ck_assert_int_eq(bg, COLOR_BLUE);
+}
+END_TEST
+
+START_TEST(test_color_content_defaults)
+{
+    start_color();
+    short r=-1,g=-1,b=-1;
+    ck_assert_int_eq(color_content(COLOR_RED, &r, &g, &b), 0);
+    ck_assert_int_eq(r, 1000);
+    ck_assert_int_eq(g, 0);
+    ck_assert_int_eq(b, 0);
+}
+END_TEST
+
+Suite *color_suite(void)
+{
+    Suite *s = suite_create("color");
+    TCase *tc = tcase_create("core");
+    tcase_add_test(tc, test_pair_content_returns_values);
+    tcase_add_test(tc, test_color_content_defaults);
+    suite_add_tcase(s, tc);
+    return s;
+}

--- a/tests/test_windows.c
+++ b/tests/test_windows.c
@@ -3,6 +3,7 @@
 
 Suite *scroll_suite(void);
 Suite *input_suite(void);
+Suite *color_suite(void);
 
 START_TEST(test_newwin_basic)
 {
@@ -150,9 +151,11 @@ int main(void)
     Suite *s1 = window_suite();
     Suite *s2 = scroll_suite();
     Suite *s3 = input_suite();
+    Suite *s4 = color_suite();
     SRunner *sr = srunner_create(s1);
     srunner_add_suite(sr, s2);
     srunner_add_suite(sr, s3);
+    srunner_add_suite(sr, s4);
     srunner_run_all(sr, CK_ENV); // use CK_ENV to get TAP or not
     int nf = srunner_ntests_failed(sr);
     srunner_free(sr);

--- a/vcurses.md
+++ b/vcurses.md
@@ -110,6 +110,8 @@ Color and attribute management helpers:
 ```c
 int start_color(void);
 int init_pair(short pair, short fg, short bg);
+int pair_content(short pair, short *fg, short *bg);
+int color_content(short color, short *r, short *g, short *b);
 int attron(int attrs);  int wattron(WINDOW *win, int attrs);
 int attroff(int attrs); int wattroff(WINDOW *win, int attrs);
 int attrset(int attrs); int wattrset(WINDOW *win, int attrs);
@@ -138,7 +140,7 @@ The header defines color constants and attribute masks:
 #define A_UNDERLINE   0x020000
 ```
 
-Use `start_color()` once after initialization, define pairs with `init_pair()` and apply them with the attribute functions above.
+Use `start_color()` once after initialization, define pairs with `init_pair()` and query them with `pair_content()`. The RGB components of the basic colors can be obtained using `color_content()`. Apply pairs with the attribute functions above.
 
 ### Cursor visibility
 


### PR DESCRIPTION
## Summary
- store RGB values for predefined colors
- add `pair_content()` and `color_content()` functions
- document new APIs in README and reference manual
- test pair and color content helpers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685476a009ec8324b0c5e92f34c03298