### PR TITLE
Implement pad support

### DIFF
--- a/include/curses.h
+++ b/include/curses.h
@@ -18,6 +18,10 @@ WINDOW *newwin(int nlines, int ncols, int begin_y, int begin_x);
 int delwin(WINDOW *win);
 WINDOW *subwin(WINDOW *orig, int nlines, int ncols, int begin_y, int begin_x);
 WINDOW *derwin(WINDOW *orig, int nlines, int ncols, int begin_y, int begin_x);
+WINDOW *newpad(int nlines, int ncols);
+WINDOW *subpad(WINDOW *orig, int nlines, int ncols, int begin_y, int begin_x);
+int prefresh(WINDOW *pad, int pminrow, int pmincol,
+             int sminrow, int smincol, int smaxrow, int smaxcol);
 int wmove(WINDOW *win, int y, int x);
 int move(int y, int x);
 int waddch(WINDOW *win, char ch);

--- a/include/vcurses.h
+++ b/include/vcurses.h
@@ -14,6 +14,10 @@ typedef struct window {
     int scroll; /* scrolling enabled */
     int delay; /* input delay in ms (-1 blocking) */
     int attr; /* current attributes */
+    int is_pad; /* is this a pad */
+    int pad_y, pad_x; /* offset into root pad */
+    char **pad_buf; /* backing buffer for pads */
+    int **pad_attr; /* attribute buffer for pads */
 } WINDOW;
 
 /* Color definitions */

--- a/tests/pad.c
+++ b/tests/pad.c
@@ -1,0 +1,46 @@
+#include <check.h>
+#include "../include/curses.h"
+
+START_TEST(test_newpad_basic)
+{
+    WINDOW *p = newpad(4,6);
+    ck_assert_ptr_nonnull(p);
+    ck_assert_int_eq(p->maxy, 4);
+    ck_assert_int_eq(p->maxx, 6);
+    ck_assert_int_eq(p->is_pad, 1);
+    delwin(p);
+}
+END_TEST
+
+START_TEST(test_subpad_offsets)
+{
+    WINDOW *p = newpad(10,10);
+    WINDOW *s = subpad(p, 3, 3, 2, 2);
+    ck_assert_ptr_nonnull(s);
+    ck_assert_ptr_eq(s->parent, p);
+    ck_assert_int_eq(s->pad_y, 2);
+    ck_assert_int_eq(s->pad_x, 2);
+    delwin(s);
+    delwin(p);
+}
+END_TEST
+
+START_TEST(test_prefresh_returns_zero)
+{
+    WINDOW *p = newpad(5,5);
+    waddstr(p, "hello");
+    ck_assert_int_eq(prefresh(p,0,0,0,0,1,4), 0);
+    delwin(p);
+}
+END_TEST
+
+Suite *pad_suite(void)
+{
+    Suite *s = suite_create("pad");
+    TCase *tc = tcase_create("core");
+    tcase_add_test(tc, test_newpad_basic);
+    tcase_add_test(tc, test_subpad_offsets);
+    tcase_add_test(tc, test_prefresh_returns_zero);
+    suite_add_tcase(s, tc);
+    return s;
+}

--- a/tests/test_windows.c
+++ b/tests/test_windows.c
@@ -4,6 +4,7 @@
 Suite *scroll_suite(void);
 Suite *input_suite(void);
 Suite *color_suite(void);
+Suite *pad_suite(void);
 
 START_TEST(test_newwin_basic)
 {
@@ -152,10 +153,12 @@ int main(void)
     Suite *s2 = scroll_suite();
     Suite *s3 = input_suite();
     Suite *s4 = color_suite();
+    Suite *s5 = pad_suite();
     SRunner *sr = srunner_create(s1);
     srunner_add_suite(sr, s2);
     srunner_add_suite(sr, s3);
     srunner_add_suite(sr, s4);
+    srunner_add_suite(sr, s5);
     srunner_run_all(sr, CK_ENV); // use CK_ENV to get TAP or not
     int nf = srunner_ntests_failed(sr);
     srunner_free(sr);


### PR DESCRIPTION
## Summary
- add backing buffer fields to `WINDOW`
- implement `newpad`, `subpad`, and `prefresh`
- support pads in `waddstr` and `wborder`
- add pad tests and include them in the test suite

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685479cdfacc83249720949eed15ebde