### PR TITLE
Add input timeout APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,12 @@ enable color handling and define up to 256 color pairs with
 defined pair. Use `pair_content(pair, &fg, &bg)` to query a pair and
 `color_content(color, &r, &g, &b)` to retrieve the RGB components of a
 color.
+
+## Input timeouts
+
+`wgetch()` can wait for input in three ways:
+
+- `nodelay(win, true)` makes reads non-blocking.
+- `wtimeout(win, ms)` specifies a delay in milliseconds for the next read.
+- `halfdelay(tenths)` sets cbreak mode and applies a timeout on `stdscr`.
+

--- a/src/input.c
+++ b/src/input.c
@@ -159,12 +159,10 @@ int wgetch(WINDOW *win) {
     char c;
     int timeout = win->delay;
 
-    if (timeout >= 0) {
-        struct pollfd pfd = { .fd = STDIN_FILENO, .events = POLLIN };
-        int pr = poll(&pfd, 1, timeout);
-        if (pr <= 0)
-            return -1;
-    }
+    struct pollfd pfd = { .fd = STDIN_FILENO, .events = POLLIN };
+    int pr = poll(&pfd, 1, timeout);
+    if (pr <= 0)
+        return -1;
 
     if (read(STDIN_FILENO, &c, 1) != 1)
         return -1;

--- a/vcurses.md
+++ b/vcurses.md
@@ -103,6 +103,16 @@ int keypad(WINDOW *win, bool yes);
 
 When keypad mode is enabled, arrow keys, function keys and other special keys are returned as predefined `KEY_*` codes such as `KEY_UP` or `KEY_F1`.
 
+Input blocking behaviour can be tuned per window:
+
+```c
+int nodelay(WINDOW *win, bool bf);  /* true for non-blocking */
+int wtimeout(WINDOW *win, int delay); /* milliseconds, -1 blocking */
+int halfdelay(int tenths); /* sets stdscr timeout */
+```
+
+`nodelay()` is shorthand for `wtimeout(win, 0)`.  Positive values passed to `wtimeout()` specify the maximum wait time in milliseconds.  `halfdelay()` enables cbreak mode and waits up to the given tenths of a second when reading from `stdscr`.
+
 ### Attributes and colors
 
 Color and attribute management helpers:


### PR DESCRIPTION
## Summary
- update `wgetch` to use `poll()` for all timeout modes
- document timeout helpers in README and in the reference guide

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68549fade344832488282abfe0399cb7