### PR TITLE
Add raw mode toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,10 @@ color.
 - `wtimeout(win, ms)` specifies a delay in milliseconds for the next read.
 - `halfdelay(tenths)` sets cbreak mode and applies a timeout on `stdscr`.
 
+## Terminal modes
+
+`initscr()` enters raw mode with echo disabled. Call `noraw()` to
+restore normal signal handling and `raw()` to enable raw mode again.
+Line buffering and echo can also be toggled with `cbreak()`/
+`nocbreak()` and `echo()`/`noecho()`.
+

--- a/include/vcurses.h
+++ b/include/vcurses.h
@@ -51,6 +51,8 @@ int echo(void);
 int noecho(void);
 int cbreak(void);
 int nocbreak(void);
+int raw(void);
+int noraw(void);
 
 #ifdef __cplusplus
 }

--- a/src/term_modes.c
+++ b/src/term_modes.c
@@ -26,3 +26,15 @@ int nocbreak(void) {
     orig_termios.c_lflag |= ICANON;
     return tcsetattr(STDIN_FILENO, TCSANOW, &orig_termios);
 }
+
+int raw(void) {
+    orig_termios.c_lflag &= ~(ICANON | ISIG);
+    orig_termios.c_cc[VMIN] = 1;
+    orig_termios.c_cc[VTIME] = 0;
+    return tcsetattr(STDIN_FILENO, TCSANOW, &orig_termios);
+}
+
+int noraw(void) {
+    orig_termios.c_lflag |= ICANON | ISIG;
+    return tcsetattr(STDIN_FILENO, TCSANOW, &orig_termios);
+}

--- a/vcurses.md
+++ b/vcurses.md
@@ -56,9 +56,13 @@ echo();    /* enable input echo */
 noecho();  /* disable echo */
 cbreak();  /* disable line buffering */
 nocbreak();
+raw();     /* disable signals and line buffering */
+noraw();
 ```
 
-`initscr()` sets raw mode with no echo by default. Use these helpers to adjust the behaviour.
+`initscr()` sets raw mode with no echo by default. Use `noraw()` to
+restore normal signal processing and `raw()` to enable it again. The
+`cbreak()` and `nocbreak()` helpers only toggle line buffering.
 
 ### Windows
 


### PR DESCRIPTION
## Summary
- expose `raw()`/`noraw()` prototypes in public header
- implement raw mode support in `term_modes.c`
- document how to toggle raw mode

## Testing
- `make test` *(fails: check.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854a15449048324b5a93f73f4209142