### PR TITLE
Add beep and flash functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,8 @@ restore normal signal handling and `raw()` to enable raw mode again.
 Line buffering and echo can also be toggled with `cbreak()`/
 `nocbreak()` and `echo()`/`noecho()`.
 
+## Alerts
+
+`beep()` writes an audible bell (\a) to the terminal. `flash()` emits a brief
+visual flash using ANSI escape codes when supported.
+

--- a/include/curses.h
+++ b/include/curses.h
@@ -114,6 +114,8 @@ int wattrset(WINDOW *win, int attrs);
 int color_set(short pair, void *opts);
 int wcolor_set(WINDOW *win, short pair, void *opts);
 int curs_set(int visibility);
+int beep(void);
+int flash(void);
 
 /* Internal helper used by the library */
 void _vcurses_apply_attr(int attr);

--- a/src/curses.c
+++ b/src/curses.c
@@ -108,3 +108,13 @@ int curs_set(int visibility) {
     fflush(stdout);
     return prev;
 }
+
+int beep(void) {
+    fputc('\a', stdout);
+    return fflush(stdout);
+}
+
+int flash(void) {
+    fputs("\x1b[?5h\x1b[?5l", stdout);
+    return fflush(stdout);
+}

--- a/vcurses.md
+++ b/vcurses.md
@@ -64,6 +64,16 @@ noraw();
 restore normal signal processing and `raw()` to enable it again. The
 `cbreak()` and `nocbreak()` helpers only toggle line buffering.
 
+### Alerts
+
+```c
+int beep(void);
+int flash(void);
+```
+
+`beep()` outputs an audible bell. `flash()` triggers a visual bell using ANSI
+escape sequences when supported.
+
 ### Windows
 
 Window creation and movement routines:


### PR DESCRIPTION
## Summary
- add `beep()` and `flash()` implementations
- expose prototypes in the public header
- document alert helpers in README and reference guide

## Testing
- `make test` *(fails: check.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854a3a44a448324a2aa4bab64ace7d7