### PR TITLE
Add color customization APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ enable color handling and define up to 256 color pairs with
 `attron`, `attroff`, or `attrset` (or their window variants) to apply a
 defined pair. Use `pair_content(pair, &fg, &bg)` to query a pair and
 `color_content(color, &r, &g, &b)` to retrieve the RGB components of a
-color.
+color. Individual colors can be redefined with `init_color(color, r, g, b)`
+after calling `start_color()`.
 
 ## Input timeouts
 

--- a/include/curses.h
+++ b/include/curses.h
@@ -104,6 +104,9 @@ int start_color(void);
 int init_pair(short pair, short fg, short bg);
 int pair_content(short pair, short *fg, short *bg);
 int color_content(short color, short *r, short *g, short *b);
+int init_color(short color, short r, short g, short b);
+int has_colors(void);
+int can_change_color(void);
 
 int attron(int attrs);
 int attroff(int attrs);

--- a/src/color.c
+++ b/src/color.c
@@ -51,3 +51,18 @@ int color_content(short color, short *r, short *g, short *b) {
         *b = _vc_colors[color].b;
     return 0;
 }
+
+int init_color(short color, short r, short g, short b) {
+    if (!_vc_colors_initialized || color < 0 || color > COLOR_WHITE)
+        return -1;
+    _vc_colors[color] = (color_rgb_t){r, g, b};
+    return 0;
+}
+
+int has_colors(void) {
+    return _vc_colors_initialized;
+}
+
+int can_change_color(void) {
+    return 1;
+}

--- a/vcursesdoc.md
+++ b/vcursesdoc.md
@@ -16,3 +16,16 @@ is typical for command prompts.
 `getstr` reads from `stdscr`, while `wgetstr` accepts the window to read from.
 Both respect keypad mode, returning special key codes if keypad is enabled.
 
+## Color customization
+
+Call `start_color()` to enable color handling. The RGB components of the
+basic colors may then be changed with:
+
+```c
+int init_color(short color, short r, short g, short b);
+```
+
+Each component ranges from 0 to 1000. Use `color_content(color, &r, &g, &b)`
+to read back the stored values. `has_colors()` reports whether color mode is
+active and `can_change_color()` always returns true in this implementation.
+


### PR DESCRIPTION
## Summary
- expose color initialization/query helpers in `curses.h`
- store and retrieve RGB values in the color module
- document how to change colors

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6854a6013ca083248dd519a78744b82d