### PR TITLE
Add pad functionality and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ AR ?= ar
 CFLAGS ?= -Iinclude -Wall -Wextra -fPIC
 BUILD := build
 LIB := libvcurses.a
-SRCS := src/vcurses.c src/init.c src/curses.c src/input.c src/window.c src/screen.c src/color.c src/resize.c src/term_modes.c src/mouse.c
+SRCS := src/vcurses.c src/init.c src/curses.c src/input.c src/window.c src/pad.c src/screen.c src/color.c src/resize.c src/term_modes.c src/mouse.c
 OBJS := $(patsubst src/%.c,$(BUILD)/%.o,$(SRCS))
 
 # Unit test configuration

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Man pages for the core API are available in `docs/man`. Useful entries
 include [initscr.3](docs/man/initscr.3) and [getch.3](docs/man/getch.3).
 Additional notes on reading strings with `getstr` are in
 [vcursesdoc.md](vcursesdoc.md).
+Pad usage is documented in the [Pads section](vcursesdoc.md#pads).
 
 ## Color support
 

--- a/include/curses.h
+++ b/include/curses.h
@@ -18,6 +18,7 @@ WINDOW *newwin(int nlines, int ncols, int begin_y, int begin_x);
 int delwin(WINDOW *win);
 WINDOW *subwin(WINDOW *orig, int nlines, int ncols, int begin_y, int begin_x);
 WINDOW *derwin(WINDOW *orig, int nlines, int ncols, int begin_y, int begin_x);
+/* Pad management */
 WINDOW *newpad(int nlines, int ncols);
 WINDOW *subpad(WINDOW *orig, int nlines, int ncols, int begin_y, int begin_x);
 int prefresh(WINDOW *pad, int pminrow, int pmincol,

--- a/src/pad.c
+++ b/src/pad.c
@@ -1,0 +1,113 @@
+#include "curses.h"
+#include <stdlib.h>
+#include <string.h>
+
+/* functions from resize.c */
+extern void _vc_register_window(WINDOW *win);
+extern void _vc_screen_puts(int y, int x, const char *str, int attr);
+
+static WINDOW *pad_root(WINDOW *pad) {
+    WINDOW *r = pad;
+    while (r->parent && r->parent->is_pad)
+        r = r->parent;
+    return r;
+}
+
+WINDOW *newpad(int nlines, int ncols) {
+    WINDOW *win = calloc(1, sizeof(WINDOW));
+    if (!win)
+        return NULL;
+    win->begy = 0;
+    win->begx = 0;
+    win->maxy = nlines;
+    win->maxx = ncols;
+    win->cury = 0;
+    win->curx = 0;
+    win->parent = NULL;
+    win->keypad_mode = 0;
+    win->scroll = 0;
+    win->delay = -1;
+    win->attr = COLOR_PAIR(0);
+    win->is_pad = 1;
+    win->pad_y = 0;
+    win->pad_x = 0;
+    win->pad_buf = malloc(sizeof(char *) * nlines);
+    win->pad_attr = malloc(sizeof(int *) * nlines);
+    if (!win->pad_buf || !win->pad_attr) {
+        free(win->pad_buf);
+        free(win->pad_attr);
+        free(win);
+        return NULL;
+    }
+    for (int r = 0; r < nlines; ++r) {
+        win->pad_buf[r] = malloc(ncols);
+        win->pad_attr[r] = malloc(sizeof(int) * ncols);
+        if (!win->pad_buf[r] || !win->pad_attr[r]) {
+            for (int i = 0; i <= r; ++i) {
+                if (i < r) {
+                    free(win->pad_buf[i]);
+                    free(win->pad_attr[i]);
+                }
+            }
+            free(win->pad_buf);
+            free(win->pad_attr);
+            free(win);
+            return NULL;
+        }
+        memset(win->pad_buf[r], ' ', ncols);
+        for (int c = 0; c < ncols; ++c)
+            win->pad_attr[r][c] = win->attr;
+    }
+    _vc_register_window(win);
+    return win;
+}
+
+WINDOW *subpad(WINDOW *orig, int nlines, int ncols, int begin_y, int begin_x) {
+    if (!orig || !orig->is_pad)
+        return NULL;
+    WINDOW *win = calloc(1, sizeof(WINDOW));
+    if (!win)
+        return NULL;
+    win->begy = 0;
+    win->begx = 0;
+    win->maxy = nlines;
+    win->maxx = ncols;
+    win->cury = 0;
+    win->curx = 0;
+    win->parent = orig;
+    win->keypad_mode = 0;
+    win->scroll = 0;
+    win->delay = -1;
+    win->attr = COLOR_PAIR(0);
+    win->is_pad = 1;
+    win->pad_y = orig->pad_y + begin_y;
+    win->pad_x = orig->pad_x + begin_x;
+    win->pad_buf = orig->pad_buf;
+    win->pad_attr = orig->pad_attr;
+    _vc_register_window(win);
+    return win;
+}
+
+int prefresh(WINDOW *pad, int pminrow, int pmincol,
+             int sminrow, int smincol, int smaxrow, int smaxcol) {
+    if (!pad || !pad->is_pad)
+        return -1;
+    WINDOW *root = pad_root(pad);
+    int rows = smaxrow - sminrow + 1;
+    int cols = smaxcol - smincol + 1;
+    for (int r = 0; r < rows; ++r) {
+        if (pminrow + r >= pad->maxy)
+            break;
+        for (int c = 0; c < cols; ++c) {
+            if (pmincol + c >= pad->maxx)
+                break;
+            int rr = pad->pad_y + pminrow + r;
+            int cc = pad->pad_x + pmincol + c;
+            char ch = root->pad_buf[rr][cc];
+            int attr = root->pad_attr[rr][cc];
+            char buf[2] = { ch, 0 };
+            _vc_screen_puts(sminrow + r, smincol + c, buf, attr);
+        }
+    }
+    return 0;
+}

--- a/src/window.c
+++ b/src/window.c
@@ -71,81 +71,6 @@ WINDOW *derwin(WINDOW *orig, int nlines, int ncols, int begin_y, int begin_x) {
     return subwin(orig, nlines, ncols, orig->begy + begin_y, orig->begx + begin_x);
 }
 
-WINDOW *newpad(int nlines, int ncols) {
-    WINDOW *win = calloc(1, sizeof(WINDOW));
-    if (!win)
-        return NULL;
-    win->begy = 0;
-    win->begx = 0;
-    win->maxy = nlines;
-    win->maxx = ncols;
-    win->cury = 0;
-    win->curx = 0;
-    win->parent = NULL;
-    win->keypad_mode = 0;
-    win->scroll = 0;
-    win->delay = -1;
-    win->attr = COLOR_PAIR(0);
-    win->is_pad = 1;
-    win->pad_y = 0;
-    win->pad_x = 0;
-    win->pad_buf = malloc(sizeof(char *) * nlines);
-    win->pad_attr = malloc(sizeof(int *) * nlines);
-    if (!win->pad_buf || !win->pad_attr) {
-        free(win->pad_buf);
-        free(win->pad_attr);
-        free(win);
-        return NULL;
-    }
-    for (int r = 0; r < nlines; ++r) {
-        win->pad_buf[r] = malloc(ncols);
-        win->pad_attr[r] = malloc(sizeof(int) * ncols);
-        if (!win->pad_buf[r] || !win->pad_attr[r]) {
-            for (int i = 0; i <= r; ++i) {
-                if (i < r) {
-                    free(win->pad_buf[i]);
-                    free(win->pad_attr[i]);
-                }
-            }
-            free(win->pad_buf);
-            free(win->pad_attr);
-            free(win);
-            return NULL;
-        }
-        memset(win->pad_buf[r], ' ', ncols);
-        for (int c = 0; c < ncols; ++c)
-            win->pad_attr[r][c] = win->attr;
-    }
-    _vc_register_window(win);
-    return win;
-}
-
-WINDOW *subpad(WINDOW *orig, int nlines, int ncols, int begin_y, int begin_x) {
-    if (!orig || !orig->is_pad)
-        return NULL;
-    WINDOW *win = calloc(1, sizeof(WINDOW));
-    if (!win)
-        return NULL;
-    win->begy = 0;
-    win->begx = 0;
-    win->maxy = nlines;
-    win->maxx = ncols;
-    win->cury = 0;
-    win->curx = 0;
-    win->parent = orig;
-    win->keypad_mode = 0;
-    win->scroll = 0;
-    win->delay = -1;
-    win->attr = COLOR_PAIR(0);
-    win->is_pad = 1;
-    win->pad_y = orig->pad_y + begin_y;
-    win->pad_x = orig->pad_x + begin_x;
-    win->pad_buf = orig->pad_buf;
-    win->pad_attr = orig->pad_attr;
-    _vc_register_window(win);
-    return win;
-}
-
 static WINDOW *pad_root(WINDOW *pad) {
     WINDOW *r = pad;
     while (r->parent && r->parent->is_pad)
@@ -153,29 +78,6 @@ static WINDOW *pad_root(WINDOW *pad) {
     return r;
 }
 
-int prefresh(WINDOW *pad, int pminrow, int pmincol,
-             int sminrow, int smincol, int smaxrow, int smaxcol) {
-    if (!pad || !pad->is_pad)
-        return -1;
-    WINDOW *root = pad_root(pad);
-    int rows = smaxrow - sminrow + 1;
-    int cols = smaxcol - smincol + 1;
-    for (int r = 0; r < rows; ++r) {
-        if (pminrow + r >= pad->maxy)
-            break;
-        for (int c = 0; c < cols; ++c) {
-            if (pmincol + c >= pad->maxx)
-                break;
-            int rr = pad->pad_y + pminrow + r;
-            int cc = pad->pad_x + pmincol + c;
-            char ch = root->pad_buf[rr][cc];
-            int attr = root->pad_attr[rr][cc];
-            char buf[2] = { ch, 0 };
-            _vc_screen_puts(sminrow + r, smincol + c, buf, attr);
-        }
-    }
-    return 0;
-}
 
 int wmove(WINDOW *win, int y, int x) {
     if (!win) {

--- a/vcursesdoc.md
+++ b/vcursesdoc.md
@@ -46,3 +46,22 @@ if (ch == KEY_MOUSE && getmouse(&me) == 0) {
 }
 ```
 
+## Pads
+
+Pads are off-screen windows with their own backing buffers. Create one with
+`newpad(rows, cols)` and write to it using the normal output functions. Use
+`subpad` to create a view into an existing pad that shares the same buffer.
+
+Unlike regular windows which draw directly to the terminal, pads store their
+contents in memory. The `prefresh` function copies a region from a pad to the
+screen:
+
+```c
+int prefresh(WINDOW *pad, int pminrow, int pmincol,
+             int sminrow, int smincol, int smaxrow, int smaxcol);
+```
+
+`pminrow` and `pmincol` select the upper-left corner of the pad region while
+`sminrow`, `smincol`, `smaxrow` and `smaxcol` specify the destination
+rectangle on screen.
+


### PR DESCRIPTION
## Summary
- move pad APIs to new `src/pad.c`
- expose pad API section in `curses.h`
- document pads in `vcursesdoc.md` and reference them in README
- update Makefile to compile new file

## Testing
- `make`
- `make test` *(fails: check.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854b94320e08324a6e413ea90ce0537