### PR TITLE
Add formatted output functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,13 @@ exposed lines are cleared using the window's current attributes.
 Mouse events can be enabled with `mousemask()` and read with `getmouse()` when
 `wgetch()` returns `KEY_MOUSE`.
 
+## Formatted output
+
+`wprintw(win, fmt, ...)` works like `printf` but writes into a window.
+`printw()` is a convenience wrapper that targets `stdscr`.
+
+```c
+wprintw(win, "Count: %d", n);
+printw("%s\n", msg);
+```
+

--- a/include/curses.h
+++ b/include/curses.h
@@ -29,6 +29,8 @@ int waddch(WINDOW *win, char ch);
 int addch(char ch);
 int addstr(const char *str);
 int waddstr(WINDOW *win, const char *str);
+int wprintw(WINDOW *win, const char *fmt, ...);
+int printw(const char *fmt, ...);
 int wgetch(WINDOW *win);
 int getch(void);
 int wgetstr(WINDOW *win, char *buf);

--- a/src/curses.c
+++ b/src/curses.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <stdarg.h>
 
 WINDOW *stdscr = NULL;
 
@@ -90,6 +91,30 @@ int addstr(const char *str) {
 
 int addch(char ch) {
     return waddch(stdscr, ch);
+}
+
+int printw(const char *fmt, ...) {
+    va_list ap, ap_copy;
+    va_start(ap, fmt);
+    va_copy(ap_copy, ap);
+    int len = vsnprintf(NULL, 0, fmt, ap_copy);
+    va_end(ap_copy);
+    if (len < 0) {
+        va_end(ap);
+        return -1;
+    }
+
+    char *buf = malloc((size_t)len + 1);
+    if (!buf) {
+        va_end(ap);
+        return -1;
+    }
+
+    vsnprintf(buf, (size_t)len + 1, fmt, ap);
+    va_end(ap);
+    int r = waddstr(stdscr, buf);
+    free(buf);
+    return r;
 }
 
 static int _cursor_state = 1;

--- a/src/window.c
+++ b/src/window.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdarg.h>
 
 /* functions from resize.c */
 extern void _vc_register_window(WINDOW *win);
@@ -123,6 +124,35 @@ int waddch(WINDOW *win, char ch) {
     buf[0] = ch;
     buf[1] = '\0';
     return waddstr(win, buf);
+}
+
+static int vwprintw_internal(WINDOW *win, const char *fmt, va_list ap) {
+    if (!win || !fmt)
+        return -1;
+
+    va_list ap_copy;
+    va_copy(ap_copy, ap);
+    int len = vsnprintf(NULL, 0, fmt, ap_copy);
+    va_end(ap_copy);
+    if (len < 0)
+        return -1;
+
+    char *buf = malloc((size_t)len + 1);
+    if (!buf)
+        return -1;
+
+    vsnprintf(buf, (size_t)len + 1, fmt, ap);
+    int r = waddstr(win, buf);
+    free(buf);
+    return r;
+}
+
+int wprintw(WINDOW *win, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    int r = vwprintw_internal(win, fmt, ap);
+    va_end(ap);
+    return r;
 }
 
 int scrollok(WINDOW *win, bool bf) {

--- a/vcursesdoc.md
+++ b/vcursesdoc.md
@@ -16,6 +16,16 @@ is typical for command prompts.
 `getstr` reads from `stdscr`, while `wgetstr` accepts the window to read from.
 Both respect keypad mode, returning special key codes if keypad is enabled.
 
+## Formatted output
+
+Use `wprintw(win, fmt, ...)` to print formatted text directly into a window.
+`printw()` performs the same operation on `stdscr`.
+
+```c
+wprintw(win, "Value %d", i);
+printw("Hello %s", name);
+```
+
 ## Color customization
 
 Call `start_color()` to enable color handling. The RGB components of the


### PR DESCRIPTION
## Summary
- implement `wprintw` in window.c
- add `printw` wrapper for stdscr
- expose prototypes in `curses.h`
- document formatted output in README and vcursesdoc

## Testing
- `make test` *(fails: Running suite(s): windows)*

------
https://chatgpt.com/codex/tasks/task_e_6854dee9a2748324bb70d78358d0f92a