### PR TITLE
Add ncurses-style window macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ exposed lines are cleared using the window's current attributes.
 Mouse events can be enabled with `mousemask()` and read with `getmouse()` when
 `wgetch()` returns `KEY_MOUSE`.
 
+## Window coordinate macros
+
+Several macros match the ncurses API for retrieving window positions. They
+expand to simple field accesses:
+
+```c
+int y, x;
+getyx(win, y, x);      /* cursor position */
+getbegyx(win, y, x);   /* window origin */
+getmaxyx(win, y, x);   /* window size */
+```
+
+Single-value helpers like `getcurx(win)` and `getmaxy(win)` are also provided.
+
 ## Formatted output
 
 `wprintw(win, fmt, ...)` works like `printf` but writes into a window.

--- a/include/curses.h
+++ b/include/curses.h
@@ -54,6 +54,20 @@ int wclear(WINDOW *win);
 int wclrtobot(WINDOW *win);
 int wclrtoeol(WINDOW *win);
 
+/* --- Convenience macros ---------------------------------------------- */
+#define getcury(win)      ((win)->cury)
+#define getcurx(win)      ((win)->curx)
+#define getbegy(win)      ((win)->begy)
+#define getbegx(win)      ((win)->begx)
+#define getmaxy(win)      ((win)->maxy)
+#define getmaxx(win)      ((win)->maxx)
+#define getpary(win)      ((win)->parent ? (win)->begy - (win)->parent->begy : -1)
+#define getparx(win)      ((win)->parent ? (win)->begx - (win)->parent->begx : -1)
+#define getyx(win,y,x)    ((y) = getcury(win), (x) = getcurx(win))
+#define getbegyx(win,y,x) ((y) = getbegy(win), (x) = getbegx(win))
+#define getmaxyx(win,y,x) ((y) = getmaxy(win), (x) = getmaxx(win))
+#define getparyx(win,y,x) ((y) = getpary(win), (x) = getparx(win))
+
 /* --- Mouse support ---------------------------------------------------- */
 typedef unsigned long mmask_t;
 

--- a/tests/macros.c
+++ b/tests/macros.c
@@ -1,0 +1,61 @@
+#include <check.h>
+#include "../include/curses.h"
+
+START_TEST(test_getyx_macro)
+{
+    WINDOW *w = newwin(3,4,1,2);
+    wmove(w,2,1);
+    int y=-1,x=-1;
+    getyx(w,y,x);
+    ck_assert_int_eq(y,2);
+    ck_assert_int_eq(x,1);
+    delwin(w);
+}
+END_TEST
+
+START_TEST(test_getbegyx_macro)
+{
+    WINDOW *w = newwin(2,5,4,7);
+    int y=-1,x=-1;
+    getbegyx(w,y,x);
+    ck_assert_int_eq(y,4);
+    ck_assert_int_eq(x,7);
+    delwin(w);
+}
+END_TEST
+
+START_TEST(test_getmaxyx_macro)
+{
+    WINDOW *w = newwin(5,6,0,0);
+    int y=-1,x=-1;
+    getmaxyx(w,y,x);
+    ck_assert_int_eq(y,5);
+    ck_assert_int_eq(x,6);
+    delwin(w);
+}
+END_TEST
+
+START_TEST(test_getparyx_macro)
+{
+    WINDOW *p = newwin(10,10,3,4);
+    WINDOW *s = subwin(p,4,4,5,7);
+    int y=-2,x=-2;
+    getparyx(s,y,x);
+    ck_assert_int_eq(y,2);
+    ck_assert_int_eq(x,3);
+    delwin(s);
+    delwin(p);
+}
+END_TEST
+
+Suite *macro_suite(void)
+{
+    Suite *s = suite_create("macros");
+    TCase *tc = tcase_create("core");
+    tcase_add_test(tc, test_getyx_macro);
+    tcase_add_test(tc, test_getbegyx_macro);
+    tcase_add_test(tc, test_getmaxyx_macro);
+    tcase_add_test(tc, test_getparyx_macro);
+    suite_add_tcase(s, tc);
+    return s;
+}

--- a/tests/test_windows.c
+++ b/tests/test_windows.c
@@ -5,6 +5,7 @@ Suite *scroll_suite(void);
 Suite *input_suite(void);
 Suite *color_suite(void);
 Suite *pad_suite(void);
+Suite *macro_suite(void);
 
 START_TEST(test_newwin_basic)
 {
@@ -171,11 +172,13 @@ int main(void)
     Suite *s3 = input_suite();
     Suite *s4 = color_suite();
     Suite *s5 = pad_suite();
+    Suite *s6 = macro_suite();
     SRunner *sr = srunner_create(s1);
     srunner_add_suite(sr, s2);
     srunner_add_suite(sr, s3);
     srunner_add_suite(sr, s4);
     srunner_add_suite(sr, s5);
+    srunner_add_suite(sr, s6);
     srunner_run_all(sr, CK_ENV); // use CK_ENV to get TAP or not
     int nf = srunner_ntests_failed(sr);
     srunner_free(sr);

--- a/vcursesdoc.md
+++ b/vcursesdoc.md
@@ -117,3 +117,23 @@ Only the specified window's backing buffers are modified. The changes become
 visible after calling `wrefresh()` or `prefresh()` as appropriate. Clearing
 operations honour the window's current attributes when filling spaces.
 
+## Window coordinate macros
+
+`vcurses` defines a set of macros that mirror those found in ncurses to
+inspect window geometry without function calls.
+
+```c
+getyx(win, y, x);      /* y = win->cury, x = win->curx */
+getbegyx(win, y, x);   /* origin of the window */
+getmaxyx(win, y, x);   /* size of the window */
+getparyx(win, y, x);   /* offsets relative to the parent or -1 */
+
+int cy = getcury(win); /* single-value forms */
+int bx = getbegx(win);
+```
+
+`getpary` and `getparx` compute the position of a subwindow relative to
+its parent and evaluate to `-1` if the window has no parent.  These
+macros operate purely on the `WINDOW` structure and therefore behave
+compatibly with applications written for ncurses.
+


### PR DESCRIPTION
## Summary
- implement common ncurses coordinate macros in `curses.h`
- document macros in README and vcursesdoc
- add macro tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6854e09aee608324b6b2941de277d696