### PR TITLE
Implement resizing functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+build/

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ exposed lines are cleared using the window's current attributes.
 the visible screen. Coordinates are clamped when necessary to keep the entire
 window on screen.
 
+## Resizing
+
+`wresize(win, lines, cols)` changes the dimensions of a window. When used on a
+pad, the backing buffers are reallocated. Call `resizeterm(lines, cols)` to
+update `stdscr` and all windows after the terminal size changes.
+
 ## Mouse input
 
 Mouse events can be enabled with `mousemask()` and read with `getmouse()` when

--- a/include/curses.h
+++ b/include/curses.h
@@ -50,6 +50,8 @@ int whline(WINDOW *win, char ch, int n);
 int hline(char ch, int n);
 int wvline(WINDOW *win, char ch, int n);
 int vline(char ch, int n);
+int wresize(WINDOW *win, int nlines, int ncols);
+int resizeterm(int lines, int cols);
 int wrefresh(WINDOW *win);
 int wclear(WINDOW *win);
 int wclrtobot(WINDOW *win);

--- a/src/resize.c
+++ b/src/resize.c
@@ -97,3 +97,13 @@ void _vc_resize_shutdown(void)
     }
 }
 
+extern void _vc_screen_free(void);
+int resizeterm(int lines, int cols)
+{
+    if (lines <= 0 || cols <= 0)
+        return -1;
+    resize_all(lines, cols);
+    _vc_screen_free();
+    return 0;
+}
+

--- a/vcursesdoc.md
+++ b/vcursesdoc.md
@@ -122,6 +122,12 @@ operations honour the window's current attributes when filling spaces.
 Use `mvwin(win, y, x)` to reposition a window. The coordinates are
 automatically adjusted so the entire window remains visible on screen.
 
+## Resizing windows
+
+Resize an existing window with `wresize(win, rows, cols)`. For pads this will
+allocate new backing buffers. When the terminal itself changes dimensions,
+call `resizeterm(rows, cols)` so `stdscr` and all windows update accordingly.
+
 ## Window coordinate macros
 
 `vcurses` defines a set of macros that mirror those found in ncurses to


### PR DESCRIPTION
## Summary
- add `wresize` to adjust window and pad dimensions
- implement `resizeterm` to resize stdscr and windows
- expose new APIs in `curses.h`
- document resizing in README and vcursesdoc
- ignore build artifacts

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6854e4f01b2c8324a81527d113886dd7