### PR TITLE
Implement input queue with ungetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ after calling `start_color()`.
 - `nodelay(win, true)` makes reads non-blocking.
 - `wtimeout(win, ms)` specifies a delay in milliseconds for the next read.
 - `halfdelay(tenths)` sets cbreak mode and applies a timeout on `stdscr`.
+- `ungetch(ch)` pushes a character back so the next `getch` returns it.
 
 ## Terminal modes
 

--- a/include/curses.h
+++ b/include/curses.h
@@ -34,6 +34,7 @@ int wprintw(WINDOW *win, const char *fmt, ...);
 int printw(const char *fmt, ...);
 int wgetch(WINDOW *win);
 int getch(void);
+int ungetch(int ch);
 int wgetstr(WINDOW *win, char *buf);
 int getstr(char *buf);
 int keypad(WINDOW *win, bool yes);

--- a/src/input.c
+++ b/src/input.c
@@ -6,6 +6,11 @@
 /* mouse event queue helper */
 extern void _vc_mouse_push_event(mmask_t bstate, int x, int y);
 
+/* simple push-back stack for characters */
+#define INPUT_QSIZE 32
+static int input_queue[INPUT_QSIZE];
+static int input_qcount = 0;
+
 static int read_number(int *out, char *delim)
 {
     char ch;
@@ -156,6 +161,9 @@ int wgetch(WINDOW *win) {
     if (!win)
         return -1;
 
+    if (input_qcount > 0)
+        return input_queue[--input_qcount];
+
     char c;
     int timeout = win->delay;
 
@@ -175,6 +183,13 @@ int wgetch(WINDOW *win) {
 
 int getch(void) {
     return wgetch(stdscr);
+}
+
+int ungetch(int ch) {
+    if (input_qcount >= INPUT_QSIZE)
+        return -1;
+    input_queue[input_qcount++] = ch;
+    return 0;
 }
 
 int wgetstr(WINDOW *win, char *buf) {

--- a/tests/input.c
+++ b/tests/input.c
@@ -34,12 +34,34 @@ START_TEST(test_wtimeout_delay)
 }
 END_TEST
 
+START_TEST(test_ungetch_single)
+{
+    WINDOW *w = newwin(1,1,0,0);
+    ck_assert_int_eq(ungetch('x'), 0);
+    ck_assert_int_eq(wgetch(w), 'x');
+    delwin(w);
+}
+END_TEST
+
+START_TEST(test_ungetch_stack_order)
+{
+    WINDOW *w = newwin(1,1,0,0);
+    ck_assert_int_eq(ungetch('a'), 0);
+    ck_assert_int_eq(ungetch('b'), 0);
+    ck_assert_int_eq(wgetch(w), 'b');
+    ck_assert_int_eq(wgetch(w), 'a');
+    delwin(w);
+}
+END_TEST
+
 Suite *input_suite(void)
 {
     Suite *s = suite_create("input");
     TCase *tc = tcase_create("core");
     tcase_add_test(tc, test_nodelay_returns_err);
     tcase_add_test(tc, test_wtimeout_delay);
+    tcase_add_test(tc, test_ungetch_single);
+    tcase_add_test(tc, test_ungetch_stack_order);
     suite_add_tcase(s, tc);
     return s;
 }

--- a/vcursesdoc.md
+++ b/vcursesdoc.md
@@ -16,6 +16,13 @@ is typical for command prompts.
 `getstr` reads from `stdscr`, while `wgetstr` accepts the window to read from.
 Both respect keypad mode, returning special key codes if keypad is enabled.
 
+## Pushing input with ungetch
+
+Characters may be placed back onto the input stream using `ungetch`.
+The next call to `getch` or `wgetch` will return the pushed value
+instead of reading from the terminal.
+
+
 ## Formatted output
 
 Use `wprintw(win, fmt, ...)` to print formatted text directly into a window.


### PR DESCRIPTION
## Summary
- add a small push-back queue for input
- implement `ungetch` in `src/input.c`
- declare function in the public header
- document input pushing in README and vcursesdoc
- add unit tests for pushing characters

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68557421ecac8324a7243b85625c7f0d