### PR TITLE
Add reverse video attribute support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ defined pair. Use `pair_content(pair, &fg, &bg)` to query a pair and
 color. Individual colors can be redefined with `init_color(color, r, g, b)`
 after calling `start_color()`.
 
+## Text attributes
+
+Attributes modify how text is displayed. `vcurses` currently supports
+`A_BOLD`, `A_UNDERLINE` and `A_REVERSE`. They can be combined with color
+pairs using `attron`/`wattron` and disabled with `attroff`/`wattroff`.
+Reverse video swaps the foreground and background colors:
+
+```c
+wattron(win, A_REVERSE);
+waddstr(win, "reversed\n");
+wattroff(win, A_REVERSE);
+```
+
 ## Input timeouts
 
 `wgetch()` can wait for input in three ways:

--- a/include/vcurses.h
+++ b/include/vcurses.h
@@ -39,6 +39,7 @@ typedef struct window {
 #define A_COLOR       0xFF00
 #define A_BOLD        0x010000
 #define A_UNDERLINE   0x020000
+#define A_REVERSE     0x040000
 
 int vc_init(void);
 WINDOW *initscr(void);

--- a/src/curses.c
+++ b/src/curses.c
@@ -35,6 +35,8 @@ static void apply_attr(int attr) {
         printf("\x1b[1m");
     if (attr & A_UNDERLINE)
         printf("\x1b[4m");
+    if (attr & A_REVERSE)
+        printf("\x1b[7m");
 }
 
 void _vcurses_apply_attr(int attr) {

--- a/tests/attr.c
+++ b/tests/attr.c
@@ -1,0 +1,23 @@
+#include <check.h>
+#include "../include/curses.h"
+
+START_TEST(test_reverse_attribute_written)
+{
+    WINDOW *p = newpad(1, 3);
+    wattron(p, A_REVERSE);
+    waddstr(p, "abc");
+    ck_assert_int_eq(p->pad_attr[0][0] & A_REVERSE, A_REVERSE);
+    ck_assert_int_eq(p->pad_attr[0][1] & A_REVERSE, A_REVERSE);
+    ck_assert_int_eq(p->pad_attr[0][2] & A_REVERSE, A_REVERSE);
+    delwin(p);
+}
+END_TEST
+
+Suite *attr_suite(void)
+{
+    Suite *s = suite_create("attr");
+    TCase *tc = tcase_create("core");
+    tcase_add_test(tc, test_reverse_attribute_written);
+    suite_add_tcase(s, tc);
+    return s;
+}

--- a/tests/test_windows.c
+++ b/tests/test_windows.c
@@ -7,6 +7,7 @@ Suite *color_suite(void);
 Suite *pad_suite(void);
 Suite *macro_suite(void);
 Suite *copy_suite(void);
+Suite *attr_suite(void);
 
 START_TEST(test_newwin_basic)
 {
@@ -175,6 +176,7 @@ int main(void)
     Suite *s5 = pad_suite();
     Suite *s6 = macro_suite();
     Suite *s7 = copy_suite();
+    Suite *s8 = attr_suite();
     SRunner *sr = srunner_create(s1);
     srunner_add_suite(sr, s2);
     srunner_add_suite(sr, s3);
@@ -182,6 +184,7 @@ int main(void)
     srunner_add_suite(sr, s5);
     srunner_add_suite(sr, s6);
     srunner_add_suite(sr, s7);
+    srunner_add_suite(sr, s8);
     srunner_run_all(sr, CK_ENV); // use CK_ENV to get TAP or not
     int nf = srunner_ntests_failed(sr);
     srunner_free(sr);

--- a/vcurses.md
+++ b/vcurses.md
@@ -166,6 +166,7 @@ The header defines color constants and attribute masks:
 #define A_COLOR       0xFF00
 #define A_BOLD        0x010000
 #define A_UNDERLINE   0x020000
+#define A_REVERSE     0x040000
 ```
 
 Use `start_color()` once after initialization, define pairs with `init_pair()` and query them with `pair_content()`. The RGB components of the basic colors can be obtained using `color_content()`. Apply pairs with the attribute functions above.

--- a/vcursesdoc.md
+++ b/vcursesdoc.md
@@ -46,6 +46,20 @@ Each component ranges from 0 to 1000. Use `color_content(color, &r, &g, &b)`
 to read back the stored values. `has_colors()` reports whether color mode is
 active and `can_change_color()` always returns true in this implementation.
 
+## Text attributes
+
+Three attribute masks control text style:
+
+```c
+#define A_BOLD        0x010000
+#define A_UNDERLINE   0x020000
+#define A_REVERSE     0x040000
+```
+
+Enable an attribute with `wattron(win, mask)` and disable it with
+`wattroff(win, mask)`. `A_REVERSE` swaps the foreground and background
+colors when output is refreshed.
+
 ## Mouse events
 
 Enable mouse reporting by calling `mousemask()` with the desired button masks.


### PR DESCRIPTION
## Summary
- define `A_REVERSE` attribute
- emit `7m` ANSI sequence when reverse attribute is active
- document attribute usage in README and documentation
- add a unit test exercising reverse video handling

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6855807944b083249a24b9def248ebb4