### PR TITLE
Add getnstr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ wattroff(win, A_REVERSE);
 - `wtimeout(win, ms)` specifies a delay in milliseconds for the next read.
 - `halfdelay(tenths)` sets cbreak mode and applies a timeout on `stdscr`.
 - `ungetch(ch)` pushes a character back so the next `getch` returns it.
+Use `getnstr()` or `wgetnstr()` to stop reading a string once a fixed
+length has been reached.
 
 ## Terminal modes
 

--- a/include/curses.h
+++ b/include/curses.h
@@ -37,6 +37,8 @@ int getch(void);
 int ungetch(int ch);
 int wgetstr(WINDOW *win, char *buf);
 int getstr(char *buf);
+int wgetnstr(WINDOW *win, char *buf, int n);
+int getnstr(char *buf, int n);
 int keypad(WINDOW *win, bool yes);
 int nodelay(WINDOW *win, bool bf);
 int wtimeout(WINDOW *win, int delay);

--- a/src/input.c
+++ b/src/input.c
@@ -209,8 +209,44 @@ int wgetstr(WINDOW *win, char *buf) {
     return -1;
 }
 
+int wgetnstr(WINDOW *win, char *buf, int n) {
+    if (!win || !buf || n <= 0)
+        return -1;
+
+    int ch;
+    int count = 0;
+
+    while (count < n && (ch = wgetch(win)) != -1) {
+        if (ch == '\n' || ch == '\r') {
+            buf[count] = '\0';
+            return 0;
+        }
+        buf[count++] = (char)ch;
+    }
+
+    if (ch == -1)
+        return -1;
+
+    buf[count] = '\0';
+
+    if (count == n) {
+        while ((ch = wgetch(win)) != -1) {
+            if (ch == '\n' || ch == '\r')
+                break;
+        }
+        if (ch == -1)
+            return -1;
+    }
+
+    return 0;
+}
+
 int getstr(char *buf) {
     return wgetstr(stdscr, buf);
+}
+
+int getnstr(char *buf, int n) {
+    return wgetnstr(stdscr, buf, n);
 }
 
 int keypad(WINDOW *win, bool yes) {

--- a/tests/input.c
+++ b/tests/input.c
@@ -70,6 +70,39 @@ START_TEST(test_resize_event)
 }
 END_TEST
 
+START_TEST(test_wgetnstr_limits_length)
+{
+    WINDOW *w = newwin(1,1,0,0);
+    ungetch('\n');
+    ungetch('c');
+    ungetch('b');
+    ungetch('a');
+    char buf[3];
+    ck_assert_int_eq(wgetnstr(w, buf, 2), 0);
+    ck_assert_str_eq(buf, "ab");
+    nodelay(w, true);
+    ck_assert_int_eq(wgetch(w), -1);
+    delwin(w);
+}
+END_TEST
+
+START_TEST(test_getnstr_wrapper)
+{
+    WINDOW *saved = stdscr;
+    stdscr = newwin(1,1,0,0);
+    ungetch('\n');
+    ungetch('y');
+    ungetch('x');
+    char buf[3];
+    ck_assert_int_eq(getnstr(buf, 2), 0);
+    ck_assert_str_eq(buf, "xy");
+    nodelay(stdscr, true);
+    ck_assert_int_eq(getch(), -1);
+    delwin(stdscr);
+    stdscr = saved;
+}
+END_TEST
+
 Suite *input_suite(void)
 {
     Suite *s = suite_create("input");
@@ -79,6 +112,8 @@ Suite *input_suite(void)
     tcase_add_test(tc, test_ungetch_single);
     tcase_add_test(tc, test_ungetch_stack_order);
     tcase_add_test(tc, test_resize_event);
+    tcase_add_test(tc, test_wgetnstr_limits_length);
+    tcase_add_test(tc, test_getnstr_wrapper);
     suite_add_tcase(s, tc);
     return s;
 }

--- a/vcursesdoc.md
+++ b/vcursesdoc.md
@@ -16,6 +16,17 @@ is typical for command prompts.
 `getstr` reads from `stdscr`, while `wgetstr` accepts the window to read from.
 Both respect keypad mode, returning special key codes if keypad is enabled.
 
+## Limiting input with getnstr
+
+When a buffer has a fixed size, use `getnstr` or `wgetnstr` to cap the number
+of characters read. The `n` argument specifies the maximum number of
+characters stored, excluding the terminating `\0`.
+
+```c
+char buf[4];
+getnstr(buf, 3); /* reads up to three characters */
+```
+
 ## Pushing input with ungetch
 
 Characters may be placed back onto the input stream using `ungetch`.


### PR DESCRIPTION
## Summary
- implement `wgetnstr` and `getnstr`
- document new functions in headers and docs
- note length-capped reading in README
- add tests for limited string input

## Testing
- `make test` *(fails: `check.h` missing initially; installed, but tests hang due to environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_685586224db48324884537e3771b94e4