### PR TITLE
Support additional attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ after calling `start_color()`.
 
 ## Text attributes
 
-Attributes modify how text is displayed. `vcurses` currently supports
-`A_BOLD`, `A_UNDERLINE` and `A_REVERSE`. They can be combined with color
-pairs using `attron`/`wattron` and disabled with `attroff`/`wattroff`.
+Attributes modify how text is displayed. `vcurses` supports
+`A_BOLD`, `A_UNDERLINE`, `A_REVERSE`, `A_BLINK`, `A_DIM` and `A_STANDOUT`.
+They can be combined with color pairs using `attron`/`wattron` and disabled
+with `attroff`/`wattroff`.
 Reverse video swaps the foreground and background colors:
 
 ```c

--- a/include/vcurses.h
+++ b/include/vcurses.h
@@ -40,6 +40,9 @@ typedef struct window {
 #define A_BOLD        0x010000
 #define A_UNDERLINE   0x020000
 #define A_REVERSE     0x040000
+#define A_BLINK       0x080000
+#define A_DIM         0x100000
+#define A_STANDOUT    0x200000
 
 int vc_init(void);
 WINDOW *initscr(void);

--- a/src/curses.c
+++ b/src/curses.c
@@ -37,6 +37,12 @@ static void apply_attr(int attr) {
         printf("\x1b[4m");
     if (attr & A_REVERSE)
         printf("\x1b[7m");
+    if (attr & A_BLINK)
+        printf("\x1b[5m");
+    if (attr & A_DIM)
+        printf("\x1b[2m");
+    if (attr & A_STANDOUT)
+        printf("\x1b[7m");
 }
 
 void _vcurses_apply_attr(int attr) {

--- a/tests/attr.c
+++ b/tests/attr.c
@@ -13,11 +13,34 @@ START_TEST(test_reverse_attribute_written)
 }
 END_TEST
 
+START_TEST(test_blink_attribute_written)
+{
+    WINDOW *p = newpad(1, 1);
+    wattron(p, A_BLINK);
+    waddch(p, 'x');
+    ck_assert_int_eq(p->pad_attr[0][0] & A_BLINK, A_BLINK);
+    delwin(p);
+}
+END_TEST
+
+START_TEST(test_combined_attributes_written)
+{
+    WINDOW *p = newpad(1, 2);
+    wattron(p, A_BOLD | A_BLINK);
+    waddstr(p, "ab");
+    ck_assert_int_eq(p->pad_attr[0][0] & (A_BOLD|A_BLINK), A_BOLD|A_BLINK);
+    ck_assert_int_eq(p->pad_attr[0][1] & (A_BOLD|A_BLINK), A_BOLD|A_BLINK);
+    delwin(p);
+}
+END_TEST
+
 Suite *attr_suite(void)
 {
     Suite *s = suite_create("attr");
     TCase *tc = tcase_create("core");
     tcase_add_test(tc, test_reverse_attribute_written);
+    tcase_add_test(tc, test_blink_attribute_written);
+    tcase_add_test(tc, test_combined_attributes_written);
     suite_add_tcase(s, tc);
     return s;
 }

--- a/vcurses.md
+++ b/vcurses.md
@@ -167,6 +167,9 @@ The header defines color constants and attribute masks:
 #define A_BOLD        0x010000
 #define A_UNDERLINE   0x020000
 #define A_REVERSE     0x040000
+#define A_BLINK       0x080000
+#define A_DIM         0x100000
+#define A_STANDOUT    0x200000
 ```
 
 Use `start_color()` once after initialization, define pairs with `init_pair()` and query them with `pair_content()`. The RGB components of the basic colors can be obtained using `color_content()`. Apply pairs with the attribute functions above.

--- a/vcursesdoc.md
+++ b/vcursesdoc.md
@@ -73,12 +73,15 @@ active and `can_change_color()` always returns true in this implementation.
 
 ## Text attributes
 
-Three attribute masks control text style:
+Attribute masks control text style:
 
 ```c
 #define A_BOLD        0x010000
 #define A_UNDERLINE   0x020000
 #define A_REVERSE     0x040000
+#define A_BLINK       0x080000
+#define A_DIM         0x100000
+#define A_STANDOUT    0x200000
 ```
 
 Enable an attribute with `wattron(win, mask)` and disable it with


### PR DESCRIPTION
## Summary
- add A_BLINK, A_DIM and A_STANDOUT attribute masks
- extend attribute output to handle new masks
- document all supported attributes
- add unit tests for blink and combined attributes

## Testing
- `CK_FORK=no ./build/tests/test_suite 2>&1 | tail -n 1`

------
https://chatgpt.com/codex/tasks/task_e_6855a0f2780c8324b2d55a5da59658ef