### PR TITLE
Add default color support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ enable color handling and define up to 256 color pairs with
 defined pair. Use `pair_content(pair, &fg, &bg)` to query a pair and
 `color_content(color, &r, &g, &b)` to retrieve the RGB components of a
 color. Individual colors can be redefined with `init_color(color, r, g, b)`
-after calling `start_color()`.
+after calling `start_color()`.  Calling `use_default_colors()` lets
+`init_pair` accept `-1` as either color to keep the terminal's default
+foreground or background.
 
 ## Text attributes
 

--- a/include/curses.h
+++ b/include/curses.h
@@ -148,6 +148,7 @@ int getmouse(MEVENT *event);
 
 
 int start_color(void);
+int use_default_colors(void);
 int init_pair(short pair, short fg, short bg);
 int pair_content(short pair, short *fg, short *bg);
 int color_content(short color, short *r, short *g, short *b);

--- a/src/color.c
+++ b/src/color.c
@@ -5,6 +5,7 @@ typedef struct { short r; short g; short b; } color_rgb_t;
 
 color_pair_t _vc_color_pairs[COLOR_PAIRS];
 int _vc_colors_initialized = 0;
+static int _vc_use_default_colors = 0;
 static color_rgb_t _vc_colors[8];
 
 int start_color(void) {
@@ -22,8 +23,17 @@ int start_color(void) {
     return 0;
 }
 
+int use_default_colors(void) {
+    _vc_use_default_colors = 1;
+    return 0;
+}
+
 int init_pair(short pair, short fg, short bg) {
     if (pair < 0 || pair >= COLOR_PAIRS)
+        return -1;
+    if (!_vc_use_default_colors && (fg < 0 || bg < 0))
+        return -1;
+    if (fg < -1 || fg > COLOR_WHITE || bg < -1 || bg > COLOR_WHITE)
         return -1;
     _vc_color_pairs[pair].fg = fg;
     _vc_color_pairs[pair].bg = bg;

--- a/src/curses.c
+++ b/src/curses.c
@@ -19,16 +19,15 @@ static void apply_attr(int attr) {
     /* reset attributes */
     printf("\x1b[0m");
 
-    if (attr & A_COLOR) {
-        short pair = PAIR_NUMBER(attr);
-        if (pair >= 0 && pair < MAX_COLOR_PAIRS && _vc_colors_initialized) {
+    if (_vc_colors_initialized) {
+        short pair = (attr & A_COLOR) ? PAIR_NUMBER(attr) : 0;
+        if (pair >= 0 && pair < MAX_COLOR_PAIRS) {
             short fg = _vc_color_pairs[pair].fg;
             short bg = _vc_color_pairs[pair].bg;
-            printf("\x1b[%d;%dm", 30 + fg, 40 + bg);
+            int fg_code = (fg == -1) ? 39 : 30 + fg;
+            int bg_code = (bg == -1) ? 49 : 40 + bg;
+            printf("\x1b[%d;%dm", fg_code, bg_code);
         }
-    } else if (_vc_colors_initialized) {
-        /* default colors */
-        printf("\x1b[%d;%dm", 30 + _vc_color_pairs[0].fg, 40 + _vc_color_pairs[0].bg);
     }
 
     if (attr & A_BOLD)
@@ -83,7 +82,8 @@ int wcolor_set(WINDOW *win, short pair, void *opts) {
     if (!win)
         return -1;
     win->attr &= ~A_COLOR;
-    win->attr |= COLOR_PAIR(pair);
+    if (pair >= 0 && pair < COLOR_PAIRS)
+        win->attr |= COLOR_PAIR(pair);
     return 0;
 }
 

--- a/tests/color.c
+++ b/tests/color.c
@@ -23,12 +23,25 @@ START_TEST(test_color_content_defaults)
 }
 END_TEST
 
+START_TEST(test_init_pair_minus_one)
+{
+    start_color();
+    use_default_colors();
+    ck_assert_int_eq(init_pair(3, -1, COLOR_BLUE), 0);
+    short fg=-2, bg=-2;
+    pair_content(3, &fg, &bg);
+    ck_assert_int_eq(fg, -1);
+    ck_assert_int_eq(bg, COLOR_BLUE);
+}
+END_TEST
+
 Suite *color_suite(void)
 {
     Suite *s = suite_create("color");
     TCase *tc = tcase_create("core");
     tcase_add_test(tc, test_pair_content_returns_values);
     tcase_add_test(tc, test_color_content_defaults);
+    tcase_add_test(tc, test_init_pair_minus_one);
     suite_add_tcase(s, tc);
     return s;
 }

--- a/tests/test_windows.c
+++ b/tests/test_windows.c
@@ -176,6 +176,17 @@ START_TEST(test_wcolor_set_pair)
 }
 END_TEST
 
+START_TEST(test_wcolor_set_minus_one)
+{
+    WINDOW *w = newwin(1, 1, 0, 0);
+    start_color();
+    use_default_colors();
+    ck_assert_int_eq(wcolor_set(w, -1, NULL), 0);
+    ck_assert_int_eq(w->attr & A_COLOR, 0);
+    delwin(w);
+}
+END_TEST
+
 START_TEST(test_wrefresh_null)
 {
     ck_assert_int_eq(wrefresh(NULL), -1);
@@ -210,6 +221,7 @@ Suite *window_suite(void)
     tcase_add_test(tc, test_subwin_parent);
     tcase_add_test(tc, test_derwin_relative);
     tcase_add_test(tc, test_wcolor_set_pair);
+    tcase_add_test(tc, test_wcolor_set_minus_one);
     tcase_add_test(tc, test_wrefresh_null);
     tcase_add_test(tc, test_wrefresh_basic);
     suite_add_tcase(s, tc);

--- a/vcursesdoc.md
+++ b/vcursesdoc.md
@@ -71,6 +71,12 @@ Each component ranges from 0 to 1000. Use `color_content(color, &r, &g, &b)`
 to read back the stored values. `has_colors()` reports whether color mode is
 active and `can_change_color()` always returns true in this implementation.
 
+Calling `use_default_colors()` permits `init_pair` to take `-1` as the
+foreground or background.  A value of `-1` leaves that component unchanged
+so the terminal's default color shows through.  When default color support is
+active, `wcolor_set(win, -1, NULL)` clears any color pair on `win` while
+preserving its other attributes.
+
 ## Text attributes
 
 Attribute masks control text style:


### PR DESCRIPTION
## Summary
- allow `init_pair()` to accept `-1` as a default color when `use_default_colors()` is called
- reset foreground/background correctly for default colors
- expose `use_default_colors()` in headers
- document default color behaviour
- test default color handling

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6855a348d4848324bee88e5c60d9baa2