### PR TITLE
Implement scroll helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ on the windows' backing buffers and do not immediately redraw the screen.
 Use `wscrl(win, lines)` to scroll a window explicitly. A positive `lines`
 value scrolls the region up while a negative value scrolls it down. Newly
 exposed lines are cleared using the window's current attributes.
+Calling `scroll(win)` moves a window up by one line if scrolling is enabled.
 
 ## Moving windows
 

--- a/include/curses.h
+++ b/include/curses.h
@@ -51,6 +51,7 @@ int wtimeout(WINDOW *win, int delay);
 int halfdelay(int tenths);
 int scrollok(WINDOW *win, bool bf);
 int wscrl(WINDOW *win, int lines);
+int scroll(WINDOW *win);
 int wborder(WINDOW *win,
             char ls, char rs, char ts, char bs,
             char tl, char tr, char bl, char br);

--- a/src/window.c
+++ b/src/window.c
@@ -228,6 +228,13 @@ int wscrl(WINDOW *win, int lines) {
     return 0;
 }
 
+/* scroll a window by one line if scrolling is enabled */
+int scroll(WINDOW *win) {
+    if (!win || !win->scroll)
+        return -1;
+    return wscrl(win, 1);
+}
+
 int wborder(WINDOW *win,
             char ls, char rs, char ts, char bs,
             char tl, char tr, char bl, char br) {

--- a/tests/scroll.c
+++ b/tests/scroll.c
@@ -34,6 +34,37 @@ START_TEST(test_wscrl_downward)
 }
 END_TEST
 
+START_TEST(test_scroll_requires_flag)
+{
+    WINDOW *w = newwin(2,1,0,0);
+    waddch(w, 'a');
+    waddch(w, 'b');
+    ck_assert_int_eq(scroll(w), -1);
+    delwin(w);
+}
+END_TEST
+
+extern int _vc_screen_get_cell(int y, int x, char *ch, int *attr);
+
+START_TEST(test_scroll_moves_content)
+{
+    WINDOW *saved = stdscr;
+    stdscr = newwin(2,1,0,0);
+    scrollok(stdscr, true);
+    waddch(stdscr, 'x');
+    wmove(stdscr,1,0);
+    waddch(stdscr, 'y');
+    ck_assert_int_eq(scroll(stdscr), 0);
+    char ch;
+    _vc_screen_get_cell(0,0,&ch,NULL);
+    ck_assert_int_eq(ch, 'y');
+    _vc_screen_get_cell(1,0,&ch,NULL);
+    ck_assert_int_eq(ch, ' ');
+    delwin(stdscr);
+    stdscr = saved;
+}
+END_TEST
+
 Suite *scroll_suite(void)
 {
     Suite *s = suite_create("scroll");
@@ -43,6 +74,8 @@ Suite *scroll_suite(void)
     tcase_add_test(tc, test_wscrl_null);
     tcase_add_test(tc, test_wscrl_basic);
     tcase_add_test(tc, test_wscrl_downward);
+    tcase_add_test(tc, test_scroll_requires_flag);
+    tcase_add_test(tc, test_scroll_moves_content);
     suite_add_tcase(s, tc);
     return s;
 }

--- a/vcursesdoc.md
+++ b/vcursesdoc.md
@@ -153,6 +153,9 @@ scrollok(log, true);
 wscrl(log, -1);   /* scroll down one line */
 ```
 
+Calling `scroll(win)` is equivalent to `wscrl(win, 1)` but requires that
+scrolling be enabled with `scrollok(win, true)`.
+
 ## Drawing lines
 
 Use `whline()` and `wvline()` to draw repeated characters from the current


### PR DESCRIPTION
## Summary
- implement `scroll(win)` in `window.c`
- expose new API in header
- document single-line scrolling
- test scrolling when enabled or disabled

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6855aea5eff88324b4f09d25657ebd3c