### PR TITLE
Add clearok flag and full-screen clear support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ end of the current line and `wclrtobot(win)` clears from the cursor to the
 bottom of the window. These helpers modify only the target window's backing
 buffers.
 
+`clearok(win, true)` requests that the next `wrefresh(win)` resets the screen
+buffer before drawing, effectively clearing the terminal.
+
 ## Copying windows
 
 `overwrite(src, dst)` copies the entire contents of one window to another.

--- a/include/curses.h
+++ b/include/curses.h
@@ -50,6 +50,7 @@ int nodelay(WINDOW *win, bool bf);
 int wtimeout(WINDOW *win, int delay);
 int halfdelay(int tenths);
 int scrollok(WINDOW *win, bool bf);
+int clearok(WINDOW *win, bool bf);
 int wscrl(WINDOW *win, int lines);
 int scroll(WINDOW *win);
 int wborder(WINDOW *win,

--- a/include/vcurses.h
+++ b/include/vcurses.h
@@ -12,6 +12,7 @@ typedef struct window {
     struct window *parent; /* parent for subwindows */
     int keypad_mode; /* keypad enabled */
     int scroll; /* scrolling enabled */
+    int clearok; /* full screen clear requested */
     int delay; /* input delay in ms (-1 blocking) */
     int attr; /* current attributes */
     int is_pad; /* is this a pad */

--- a/src/pad.c
+++ b/src/pad.c
@@ -26,6 +26,7 @@ WINDOW *newpad(int nlines, int ncols) {
     win->parent = NULL;
     win->keypad_mode = 0;
     win->scroll = 0;
+    win->clearok = 0;
     win->delay = -1;
     win->attr = COLOR_PAIR(0);
     win->is_pad = 1;
@@ -81,6 +82,7 @@ WINDOW *subpad(WINDOW *orig, int nlines, int ncols, int begin_y, int begin_x) {
     win->parent = orig;
     win->keypad_mode = 0;
     win->scroll = 0;
+    win->clearok = 0;
     win->delay = -1;
     win->attr = COLOR_PAIR(0);
     win->is_pad = 1;

--- a/src/window.c
+++ b/src/window.c
@@ -38,6 +38,7 @@ WINDOW *newwin(int nlines, int ncols, int begin_y, int begin_x) {
     win->parent = NULL;
     win->keypad_mode = 0;
     win->scroll = 0;
+    win->clearok = 0;
     win->delay = -1;
     win->attr = COLOR_PAIR(0);
     win->is_pad = 0;
@@ -228,6 +229,13 @@ int scrollok(WINDOW *win, bool bf) {
     if (!win)
         return -1;
     win->scroll = bf ? 1 : 0;
+    return 0;
+}
+
+int clearok(WINDOW *win, bool bf) {
+    if (!win)
+        return -1;
+    win->clearok = bf ? 1 : 0;
     return 0;
 }
 
@@ -423,6 +431,12 @@ extern void _vc_screen_refresh_region(int top, int left, int height, int width);
 int wrefresh(WINDOW *win) {
     if (!win)
         return -1;
+    if (win->clearok) {
+        extern void _vc_screen_free(void);
+        _vc_screen_free();
+        clear();
+        win->clearok = 0;
+    }
     if (!win->dirty) {
         _vc_screen_refresh_region(win->begy, win->begx, win->maxy, win->maxx);
     } else {

--- a/tests/clear.c
+++ b/tests/clear.c
@@ -1,0 +1,46 @@
+#include <check.h>
+#include "../include/curses.h"
+
+extern int _vc_screen_get_cell(int y, int x, char *ch, int *attr);
+
+START_TEST(test_clearok_flag)
+{
+    WINDOW *w = newwin(1,1,0,0);
+    ck_assert_int_eq(clearok(w, true), 0);
+    ck_assert_int_eq(w->clearok, 1);
+    ck_assert_int_eq(clearok(w, false), 0);
+    ck_assert_int_eq(w->clearok, 0);
+    delwin(w);
+}
+END_TEST
+
+START_TEST(test_clearok_clears_screen)
+{
+    WINDOW *saved = stdscr;
+    stdscr = newwin(2,2,0,0);
+    waddstr(stdscr, "ab");
+    wmove(stdscr,1,0);
+    waddstr(stdscr, "cd");
+    wrefresh(stdscr);
+    clearok(stdscr, true);
+    wrefresh(stdscr);
+    char ch;
+    for(int r=0;r<2;r++)
+        for(int c=0;c<2;c++) {
+            _vc_screen_get_cell(r,c,&ch,NULL);
+            ck_assert_int_eq(ch,' ');
+        }
+    delwin(stdscr);
+    stdscr = saved;
+}
+END_TEST
+
+Suite *clear_suite(void)
+{
+    Suite *s = suite_create("clear");
+    TCase *tc = tcase_create("core");
+    tcase_add_test(tc, test_clearok_flag);
+    tcase_add_test(tc, test_clearok_clears_screen);
+    suite_add_tcase(s, tc);
+    return s;
+}

--- a/tests/test_windows.c
+++ b/tests/test_windows.c
@@ -10,6 +10,7 @@ Suite *copy_suite(void);
 Suite *attr_suite(void);
 Suite *erase_suite(void);
 Suite *touch_suite(void);
+Suite *clear_suite(void);
 
 START_TEST(test_newwin_basic)
 {
@@ -241,6 +242,7 @@ int main(void)
     Suite *s8 = attr_suite();
     Suite *s9 = erase_suite();
     Suite *s10 = touch_suite();
+    Suite *s11 = clear_suite();
     SRunner *sr = srunner_create(s1);
     srunner_add_suite(sr, s2);
     srunner_add_suite(sr, s3);
@@ -251,6 +253,7 @@ int main(void)
     srunner_add_suite(sr, s8);
     srunner_add_suite(sr, s9);
     srunner_add_suite(sr, s10);
+    srunner_add_suite(sr, s11);
     srunner_run_all(sr, CK_ENV); // use CK_ENV to get TAP or not
     int nf = srunner_ntests_failed(sr);
     srunner_free(sr);

--- a/vcursesdoc.md
+++ b/vcursesdoc.md
@@ -196,6 +196,19 @@ operations honour the window's current attributes when filling spaces.
 Use `werase()` (or `erase()` for `stdscr`) when you simply need to blank the
 buffers without forcing a full terminal clear on the next refresh.
 
+Calling `clearok(win, true)` marks a window so that the next `wrefresh(win)`
+resets the internal screen buffer and clears the terminal before redrawing.
+The flag is cleared afterward. This is helpful when an external program has
+disturbed the display or you simply want to ensure a blank screen.
+
+```c
+/* restore a pristine display */
+wrefresh(stdscr);
+system("some-command");
+clearok(stdscr, true);
+wrefresh(stdscr); /* screen is cleared */
+```
+
 ## Copying windows
 
 Use `overwrite(src, dst)` to duplicate the contents of one window into


### PR DESCRIPTION
## Summary
- add `clearok` field to `WINDOW`
- implement `clearok()` API
- reset screen buffer in `wrefresh` when clear flag is set
- document the new behavior in README and vcursesdoc
- test full-screen clearing

## Testing
- `env CK_FORK=no ./build/tests/test_suite`

------
https://chatgpt.com/codex/tasks/task_e_6855c0f536488324a340466bdba43908