### PR TITLE
Add ACS constants and support in drawing functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ include [initscr.3](docs/man/initscr.3) and [getch.3](docs/man/getch.3).
 Additional notes on reading strings with `getstr` are in
 [vcursesdoc.md](vcursesdoc.md).
 Pad usage is documented in the [Pads section](vcursesdoc.md#pads).
+Line drawing constants like `ACS_HLINE` are listed in the
+[ACS section](vcursesdoc.md#acs-line-drawing-characters).
 
 ## Color support
 

--- a/include/curses.h
+++ b/include/curses.h
@@ -183,6 +183,33 @@ int getmouse(MEVENT *event);
 #define KEY_F11    KEY_F(11)
 #define KEY_F12    KEY_F(12)
 
+/* Alternate character set constants */
+#define ACS_ULCORNER  0x80
+#define ACS_LLCORNER  0x81
+#define ACS_URCORNER  0x82
+#define ACS_LRCORNER  0x83
+#define ACS_LTEE      0x84
+#define ACS_RTEE      0x85
+#define ACS_TTEE      0x86
+#define ACS_BTEE      0x87
+#define ACS_HLINE     0x88
+#define ACS_VLINE     0x89
+#define ACS_PLUS      0x8A
+#define ACS_S1        0x8B
+#define ACS_S9        0x8C
+#define ACS_DIAMOND   0x8D
+#define ACS_CKBOARD   0x8E
+#define ACS_DEGREE    0x8F
+#define ACS_PLMINUS   0x90
+#define ACS_BULLET    0x91
+#define ACS_LARROW    0x92
+#define ACS_RARROW    0x93
+#define ACS_UARROW    0x94
+#define ACS_DARROW    0x95
+#define ACS_BOARD     0x96
+#define ACS_LANTERN   0x97
+#define ACS_BLOCK     0x98
+
 
 int start_color(void);
 int use_default_colors(void);

--- a/src/window.c
+++ b/src/window.c
@@ -11,6 +11,48 @@ extern void _vc_register_window(WINDOW *win);
 extern void _vc_unregister_window(WINDOW *win);
 static int vwprintw_internal(WINDOW *win, const char *fmt, va_list ap);
 
+static char acs_translate(char ch) {
+    switch ((unsigned char)ch) {
+    case ACS_ULCORNER:
+    case ACS_URCORNER:
+    case ACS_LLCORNER:
+    case ACS_LRCORNER:
+    case ACS_LTEE:
+    case ACS_RTEE:
+    case ACS_TTEE:
+    case ACS_BTEE:
+    case ACS_PLUS:
+        return '+';
+    case ACS_HLINE:
+    case ACS_S1:
+    case ACS_S9:
+        return '-';
+    case ACS_VLINE:
+        return '|';
+    case ACS_DIAMOND:
+    case ACS_BOARD:
+    case ACS_LANTERN:
+    case ACS_BLOCK:
+        return '#';
+    case ACS_CKBOARD:
+        return 'X';
+    case ACS_DEGREE:
+    case ACS_PLMINUS:
+    case ACS_BULLET:
+        return '*';
+    case ACS_LARROW:
+        return '<';
+    case ACS_RARROW:
+        return '>';
+    case ACS_UARROW:
+        return '^';
+    case ACS_DARROW:
+        return 'v';
+    default:
+        return ch;
+    }
+}
+
 static void mark_dirty(WINDOW *win, int start, int count)
 {
     if (!win || !win->dirty)
@@ -345,6 +387,15 @@ int wborder(WINDOW *win,
     if (!bl) bl = '+';
     if (!br) br = '+';
 
+    ls = acs_translate(ls);
+    rs = acs_translate(rs);
+    ts = acs_translate(ts);
+    bs = acs_translate(bs);
+    tl = acs_translate(tl);
+    tr = acs_translate(tr);
+    bl = acs_translate(bl);
+    br = acs_translate(br);
+
     int height = win->maxy;
     int width = win->maxx;
 
@@ -426,6 +477,7 @@ int whline(WINDOW *win, char ch, int n) {
         return -1;
     if (!ch)
         ch = '-';
+    ch = acs_translate(ch);
 
     char buf[2] = { ch, 0 };
     int drawn = 0;
@@ -459,6 +511,7 @@ int wvline(WINDOW *win, char ch, int n) {
         return -1;
     if (!ch)
         ch = '|';
+    ch = acs_translate(ch);
 
     char buf[2] = { ch, 0 };
     int drawn = 0;

--- a/vcursesdoc.md
+++ b/vcursesdoc.md
@@ -170,6 +170,23 @@ whline(win, '-', 10); /* horizontal line */
 wvline(win, '|', 5);  /* vertical line */
 ```
 
+### ACS line drawing characters
+
+Mnemonic constants such as `ACS_HLINE` and `ACS_VLINE` map to the ASCII
+characters used for simple boxes. They can be passed to `box`, `wborder`,
+`whline` or `wvline`:
+
+```c
+box(win, ACS_VLINE, ACS_HLINE);
+wborder(win, ACS_VLINE, ACS_VLINE,
+        ACS_HLINE, ACS_HLINE,
+        ACS_ULCORNER, ACS_URCORNER,
+        ACS_LLCORNER, ACS_LRCORNER);
+```
+
+The library translates these values to printable characters so programs work
+even without Unicode line drawing support.
+
 ## Inserting and deleting characters
 
 Characters and strings can be inserted before the cursor using


### PR DESCRIPTION
## Summary
- define ACS_* constants
- translate ACS values to ASCII when drawing
- document ACS usage
- mention ACS section in README

## Testing
- `make clean`
- `make`
- `make test` *(fails: check.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68562aa520bc8324b3e57a058ade23d1