### PR TITLE
Implement nl/nonl terminal functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ special keys to predefined constants such as `KEY_UP`, `KEY_F1`,
 `initscr()` enters raw mode with echo disabled. Call `noraw()` to
 restore normal signal handling and `raw()` to enable raw mode again.
 Line buffering and echo can also be toggled with `cbreak()`/
-`nocbreak()` and `echo()`/`noecho()`.
+`nocbreak()` and `echo()`/`noecho()`.  Newline translation can be
+controlled with `nl()` to map `\n` to `\r\n` or `nonl()` to disable
+the mapping.
 
 ## Alerts
 

--- a/include/curses.h
+++ b/include/curses.h
@@ -263,6 +263,8 @@ int bkgdset(int attrs);
 int wbkgd(WINDOW *win, int attrs);
 int bkgd(int attrs);
 int curs_set(int visibility);
+int nl(void);
+int nonl(void);
 int beep(void);
 int flash(void);
 

--- a/src/term_modes.c
+++ b/src/term_modes.c
@@ -38,3 +38,13 @@ int noraw(void) {
     orig_termios.c_lflag |= ICANON | ISIG;
     return tcsetattr(STDIN_FILENO, TCSANOW, &orig_termios);
 }
+
+int nl(void) {
+    orig_termios.c_oflag |= ONLCR;
+    return tcsetattr(STDIN_FILENO, TCSANOW, &orig_termios);
+}
+
+int nonl(void) {
+    orig_termios.c_oflag &= ~ONLCR;
+    return tcsetattr(STDIN_FILENO, TCSANOW, &orig_termios);
+}

--- a/tests/term_modes.c
+++ b/tests/term_modes.c
@@ -1,0 +1,31 @@
+#include <check.h>
+#include "../include/curses.h"
+#include <termios.h>
+
+extern struct termios orig_termios;
+
+START_TEST(test_nl_sets_onlcr)
+{
+    orig_termios.c_oflag = 0;
+    nl();
+    ck_assert_int_eq(orig_termios.c_oflag & ONLCR, ONLCR);
+}
+END_TEST
+
+START_TEST(test_nonl_clears_onlcr)
+{
+    orig_termios.c_oflag = ONLCR;
+    nonl();
+    ck_assert_int_eq(orig_termios.c_oflag & ONLCR, 0);
+}
+END_TEST
+
+Suite *term_modes_suite(void)
+{
+    Suite *s = suite_create("term_modes");
+    TCase *tc = tcase_create("core");
+    tcase_add_test(tc, test_nl_sets_onlcr);
+    tcase_add_test(tc, test_nonl_clears_onlcr);
+    suite_add_tcase(s, tc);
+    return s;
+}

--- a/tests/test_windows.c
+++ b/tests/test_windows.c
@@ -11,6 +11,7 @@ Suite *attr_suite(void);
 Suite *erase_suite(void);
 Suite *touch_suite(void);
 Suite *clear_suite(void);
+Suite *term_modes_suite(void);
 
 START_TEST(test_newwin_basic)
 {
@@ -243,6 +244,7 @@ int main(void)
     Suite *s9 = erase_suite();
     Suite *s10 = touch_suite();
     Suite *s11 = clear_suite();
+    Suite *s12 = term_modes_suite();
     SRunner *sr = srunner_create(s1);
     srunner_add_suite(sr, s2);
     srunner_add_suite(sr, s3);
@@ -254,6 +256,7 @@ int main(void)
     srunner_add_suite(sr, s9);
     srunner_add_suite(sr, s10);
     srunner_add_suite(sr, s11);
+    srunner_add_suite(sr, s12);
     srunner_run_all(sr, CK_ENV); // use CK_ENV to get TAP or not
     int nf = srunner_ntests_failed(sr);
     srunner_free(sr);

--- a/vcursesdoc.md
+++ b/vcursesdoc.md
@@ -70,6 +70,25 @@ Calling `meta(win, true)` causes `wgetch()` to return 8-bit characters
 unchanged. When disabled the high bit is stripped so bytes above 0x7F are
 masked to 7 bits.
 
+## Terminal modes
+
+Functions that control how input and output are processed:
+
+```c
+int echo(void);      /* enable input echo */
+int noecho(void);    /* disable input echo */
+int cbreak(void);    /* disable line buffering */
+int nocbreak(void);
+int raw(void);       /* disable signals and line buffering */
+int noraw(void);
+int nl(void);        /* map \n to \r\n on output */
+int nonl(void);      /* disable newline mapping */
+```
+
+`initscr()` enters raw mode with echo disabled. `nl()` enables newline
+translation so each `\n` sent to the terminal becomes a carriage return
+followed by a line feed. `nonl()` leaves `\n` unchanged.
+
 ## Formatted output
 
 Use `wprintw(win, fmt, ...)` to print formatted text directly into a window.


### PR DESCRIPTION
## Summary
- add `nl` and `nonl` to modify ONLCR
- expose prototypes in curses.h
- document newline translation in README and vcursesdoc
- test newline mapping behaviour

## Testing
- `make test` *(fails: check library not fully functional in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6857119db9e883248e0262814abce8f4