### PR TITLE
Add keyname lookup function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ AR ?= ar
 CFLAGS ?= -Iinclude -Wall -Wextra -fPIC
 BUILD := build
 LIB := libvcurses.a
-SRCS := src/vcurses.c src/init.c src/curses.c src/input.c src/window.c src/pad.c src/screen.c src/color.c src/resize.c src/term_modes.c src/mouse.c src/copywin.c src/panel.c
+SRCS := src/vcurses.c src/init.c src/curses.c src/input.c src/keyname.c \
+       src/window.c src/pad.c src/screen.c src/color.c src/resize.c \
+       src/term_modes.c src/mouse.c src/copywin.c src/panel.c
 OBJS := $(patsubst src/%.c,$(BUILD)/%.o,$(SRCS))
 
 # Unit test configuration

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ When keypad mode is enabled with `keypad(win, true)`, `wgetch()` maps
 special keys to predefined constants such as `KEY_UP`, `KEY_F1`,
 `KEY_BACKSPACE` and `KEY_ENTER`.  A full list is available in
 [vcursesdoc.md](vcursesdoc.md#key-codes).
+Use `keyname(ch)` to convert a returned key code back to a readable
+string.
 
 ## Terminal modes
 

--- a/include/curses.h
+++ b/include/curses.h
@@ -80,6 +80,7 @@ int wscanw(WINDOW *win, const char *fmt, ...);
 int scanw(const char *fmt, ...);
 int mvwscanw(WINDOW *win, int y, int x, const char *fmt, ...);
 int mvscanw(int y, int x, const char *fmt, ...);
+const char *keyname(int ch);
 int keypad(WINDOW *win, bool yes);
 int nodelay(WINDOW *win, bool bf);
 int notimeout(WINDOW *win, bool bf);

--- a/src/keyname.c
+++ b/src/keyname.c
@@ -1,0 +1,46 @@
+#include "curses.h"
+
+struct keyname_entry { int code; const char *name; };
+
+static const struct keyname_entry key_table[] = {
+    {KEY_UP, "KEY_UP"},
+    {KEY_DOWN, "KEY_DOWN"},
+    {KEY_LEFT, "KEY_LEFT"},
+    {KEY_RIGHT, "KEY_RIGHT"},
+    {KEY_HOME, "KEY_HOME"},
+    {KEY_END, "KEY_END"},
+    {KEY_NPAGE, "KEY_NPAGE"},
+    {KEY_PPAGE, "KEY_PPAGE"},
+    {KEY_IC, "KEY_IC"},
+    {KEY_DC, "KEY_DC"},
+    {KEY_BACKSPACE, "KEY_BACKSPACE"},
+    {KEY_ENTER, "KEY_ENTER"},
+    {KEY_F1, "KEY_F1"},
+    {KEY_F2, "KEY_F2"},
+    {KEY_F3, "KEY_F3"},
+    {KEY_F4, "KEY_F4"},
+    {KEY_F5, "KEY_F5"},
+    {KEY_F6, "KEY_F6"},
+    {KEY_F7, "KEY_F7"},
+    {KEY_F8, "KEY_F8"},
+    {KEY_F9, "KEY_F9"},
+    {KEY_F10, "KEY_F10"},
+    {KEY_F11, "KEY_F11"},
+    {KEY_F12, "KEY_F12"},
+    {KEY_MOUSE, "KEY_MOUSE"},
+    {KEY_RESIZE, "KEY_RESIZE"},
+};
+
+const char *keyname(int ch) {
+    if (ch >= 32 && ch < 127) {
+        static char s[2];
+        s[0] = (char)ch;
+        s[1] = '\0';
+        return s;
+    }
+    for (unsigned i = 0; i < sizeof(key_table)/sizeof(key_table[0]); ++i) {
+        if (key_table[i].code == ch)
+            return key_table[i].name;
+    }
+    return NULL;
+}

--- a/vcursesdoc.md
+++ b/vcursesdoc.md
@@ -46,6 +46,41 @@ constants defined in `<curses.h>`.  These include:
 
 Regular printable characters are returned unchanged.
 
+### keyname lookup table
+
+`keyname(ch)` returns a string describing a key code. Printable ASCII
+characters are returned as one-character strings. Special codes resolve to
+the names shown below:
+
+| Code | String |
+|------|--------|
+| `KEY_UP` | "KEY_UP" |
+| `KEY_DOWN` | "KEY_DOWN" |
+| `KEY_LEFT` | "KEY_LEFT" |
+| `KEY_RIGHT` | "KEY_RIGHT" |
+| `KEY_HOME` | "KEY_HOME" |
+| `KEY_END` | "KEY_END" |
+| `KEY_NPAGE` | "KEY_NPAGE" |
+| `KEY_PPAGE` | "KEY_PPAGE" |
+| `KEY_IC` | "KEY_IC" |
+| `KEY_DC` | "KEY_DC" |
+| `KEY_BACKSPACE` | "KEY_BACKSPACE" |
+| `KEY_ENTER` | "KEY_ENTER" |
+| `KEY_F1` | "KEY_F1" |
+| `KEY_F2` | "KEY_F2" |
+| `KEY_F3` | "KEY_F3" |
+| `KEY_F4` | "KEY_F4" |
+| `KEY_F5` | "KEY_F5" |
+| `KEY_F6` | "KEY_F6" |
+| `KEY_F7` | "KEY_F7" |
+| `KEY_F8` | "KEY_F8" |
+| `KEY_F9` | "KEY_F9" |
+| `KEY_F10` | "KEY_F10" |
+| `KEY_F11` | "KEY_F11" |
+| `KEY_F12` | "KEY_F12" |
+| `KEY_MOUSE` | "KEY_MOUSE" |
+| `KEY_RESIZE` | "KEY_RESIZE" |
+
 ## Input timeouts
 
 Input waiting behaviour can be configured per window.  The helpers


### PR DESCRIPTION
## Summary
- provide `keyname()` implementation and expose it
- document lookup in README and vcursesdoc
- compile new source via Makefile

## Testing
- `make`
- `make test` *(fails: check.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6857130fbcf48324862a63477b1ec669