### PR TITLE
Add has_key detection function

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ special keys to predefined constants such as `KEY_UP`, `KEY_F1`,
 `KEY_BACKSPACE` and `KEY_ENTER`.  A full list is available in
 [vcursesdoc.md](vcursesdoc.md#key-codes).
 Use `keyname(ch)` to convert a returned key code back to a readable
-string.
+string. The helper `has_key(code)` returns non-zero when `code` is one of
+the defined `KEY_*` constants.
 
 ## Terminal modes
 

--- a/include/curses.h
+++ b/include/curses.h
@@ -81,6 +81,7 @@ int scanw(const char *fmt, ...);
 int mvwscanw(WINDOW *win, int y, int x, const char *fmt, ...);
 int mvscanw(int y, int x, const char *fmt, ...);
 const char *keyname(int ch);
+int has_key(int keycode);
 int keypad(WINDOW *win, bool yes);
 int nodelay(WINDOW *win, bool bf);
 int notimeout(WINDOW *win, bool bf);

--- a/src/keyname.c
+++ b/src/keyname.c
@@ -44,3 +44,11 @@ const char *keyname(int ch) {
     }
     return NULL;
 }
+
+int has_key(int keycode) {
+    for (unsigned i = 0; i < sizeof(key_table)/sizeof(key_table[0]); ++i) {
+        if (key_table[i].code == keycode)
+            return 1;
+    }
+    return 0;
+}

--- a/tests/has_key.c
+++ b/tests/has_key.c
@@ -1,0 +1,26 @@
+#include <check.h>
+#include "../include/curses.h"
+
+START_TEST(test_has_key_recognizes_defined)
+{
+    ck_assert_int_ne(has_key(KEY_UP), 0);
+    ck_assert_int_ne(has_key(KEY_F5), 0);
+}
+END_TEST
+
+START_TEST(test_has_key_returns_zero_for_normal_chars)
+{
+    ck_assert_int_eq(has_key('a'), 0);
+    ck_assert_int_eq(has_key(0x30), 0);
+}
+END_TEST
+
+Suite *has_key_suite(void)
+{
+    Suite *s = suite_create("has_key");
+    TCase *tc = tcase_create("core");
+    tcase_add_test(tc, test_has_key_recognizes_defined);
+    tcase_add_test(tc, test_has_key_returns_zero_for_normal_chars);
+    suite_add_tcase(s, tc);
+    return s;
+}

--- a/tests/test_windows.c
+++ b/tests/test_windows.c
@@ -12,6 +12,7 @@ Suite *erase_suite(void);
 Suite *touch_suite(void);
 Suite *clear_suite(void);
 Suite *term_modes_suite(void);
+Suite *has_key_suite(void);
 
 START_TEST(test_newwin_basic)
 {
@@ -245,6 +246,7 @@ int main(void)
     Suite *s10 = touch_suite();
     Suite *s11 = clear_suite();
     Suite *s12 = term_modes_suite();
+    Suite *s13 = has_key_suite();
     SRunner *sr = srunner_create(s1);
     srunner_add_suite(sr, s2);
     srunner_add_suite(sr, s3);
@@ -257,6 +259,7 @@ int main(void)
     srunner_add_suite(sr, s10);
     srunner_add_suite(sr, s11);
     srunner_add_suite(sr, s12);
+    srunner_add_suite(sr, s13);
     srunner_run_all(sr, CK_ENV); // use CK_ENV to get TAP or not
     int nf = srunner_ntests_failed(sr);
     srunner_free(sr);

--- a/vcursesdoc.md
+++ b/vcursesdoc.md
@@ -45,6 +45,7 @@ constants defined in `<curses.h>`.  These include:
 - `KEY_MOUSE` and `KEY_RESIZE`
 
 Regular printable characters are returned unchanged.
+`has_key(code)` returns non-zero when `code` matches one of these constants.
 
 ### keyname lookup table
 


### PR DESCRIPTION
## Summary
- implement new has_key() API
- expose has_key in headers
- document has_key in README and main docs
- add unit tests

## Testing
- `make`
- `make test` *(fails: tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_685713e782dc8324b70fcb1f945b54e9