### PR TITLE
Implement napms and document timing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD := build
 LIB := libvcurses.a
 SRCS := src/vcurses.c src/init.c src/curses.c src/input.c src/keyname.c \
        src/window.c src/pad.c src/screen.c src/color.c src/resize.c \
-       src/term_modes.c src/mouse.c src/copywin.c src/panel.c
+       src/term_modes.c src/mouse.c src/copywin.c src/panel.c src/napms.c
 OBJS := $(patsubst src/%.c,$(BUILD)/%.o,$(SRCS))
 
 # Unit test configuration

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ the mapping.
 ## Alerts
 
 `beep()` writes an audible bell (\a) to the terminal. `flash()` emits a brief
-visual flash using ANSI escape codes when supported.
+visual flash using ANSI escape codes when supported. `napms(ms)` pauses for
+the specified number of milliseconds.
 
 `refresh()` redraws the entire screen from the internal buffer. Use
 `wrefresh(win)` to update only a specific window when you don't need to

--- a/include/curses.h
+++ b/include/curses.h
@@ -270,6 +270,7 @@ int nl(void);
 int nonl(void);
 int beep(void);
 int flash(void);
+int napms(int ms);
 
 /* Internal helper used by the library */
 void _vcurses_apply_attr(int attr);

--- a/src/napms.c
+++ b/src/napms.c
@@ -1,0 +1,8 @@
+#include "curses.h"
+#include <unistd.h>
+
+int napms(int ms) {
+    if (ms < 0)
+        return -1;
+    return usleep((useconds_t)ms * 1000);
+}

--- a/vcursesdoc.md
+++ b/vcursesdoc.md
@@ -126,6 +126,12 @@ int nonl(void);      /* disable newline mapping */
 translation so each `\n` sent to the terminal becomes a carriage return
 followed by a line feed. `nonl()` leaves `\n` unchanged.
 
+## Timing functions
+
+`napms(ms)` sleeps for `ms` milliseconds without affecting the terminal.
+Input waiting can also be tuned with `wtimeout`, `halfdelay` and
+`set_escdelay`, all described earlier under [Input timeouts](#input-timeouts).
+
 ## Formatted output
 
 Use `wprintw(win, fmt, ...)` to print formatted text directly into a window.


### PR DESCRIPTION
## Summary
- add napms implementation using `usleep`
- expose napms in `curses.h`
- compile new file by default
- mention napms briefly in README
- document timing functions in vcursesdoc

## Testing
- `make`
- `make test` *(fails: check.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_685716c244808324baa711268632961f