### PR TITLE
Add ESCDELAY environment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ window using the new attribute.
 - `halfdelay(tenths)` sets cbreak mode and applies a timeout on `stdscr`.
 - `set_escdelay(ms)` adjusts how long `wgetch()` waits after an ESC
   character before deciding it's a lone escape key.
+- The `ESCDELAY` environment variable can set this delay at startup.
 - `mouseinterval(ms)` sets the press/release interval used for clicks.
 - `notimeout(win, true)` bypasses the escape delay for that window.
 - `meta(win, true)` causes `wgetch()` to return 8-bit input values

--- a/src/init.c
+++ b/src/init.c
@@ -82,6 +82,7 @@ static SCREEN *alloc_screen(void) {
 
 SCREEN *newterm(const char *type, FILE *outf, FILE *inf) {
     (void)type; (void)outf; (void)inf;
+    vc_init();
     if (ensure_term_initialized() == -1)
         return NULL;
     return alloc_screen();

--- a/src/vcurses.c
+++ b/src/vcurses.c
@@ -1,8 +1,16 @@
-#include "vcurses.h"
+#include "curses.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 
-/* Initialize vcurses. Currently does nothing. */
+/* Initialize vcurses. Reads ESCDELAY from the environment. */
 int vc_init(void) {
+    const char *env = getenv("ESCDELAY");
+    if (env) {
+        char *end;
+        long v = strtol(env, &end, 10);
+        if (end != env && v >= 0)
+            set_escdelay((int)v);
+    }
     return 0;
 }

--- a/vcursesdoc.md
+++ b/vcursesdoc.md
@@ -105,7 +105,9 @@ int meta(WINDOW *win, bool bf);      /* return 8-bit input */
 
 When `notimeout` is enabled, `wgetch()` does not pause after an ESC
 character before returning it.  Otherwise the delay from `set_escdelay`
-is used to decide whether an escape sequence is pending.
+is used to decide whether an escape sequence is pending.  The initial
+value may also be specified through the `ESCDELAY` environment
+variable.
 
 Calling `meta(win, true)` causes `wgetch()` to return 8-bit characters
 unchanged. When disabled the high bit is stripped so bytes above 0x7F are


### PR DESCRIPTION
## Summary
- allow vcurses to read ESCDELAY from the environment
- initialize ESCDELAY before setting up the terminal
- document ESCDELAY in README and vcursesdoc

## Testing
- `make`
- `make test` *(fails: check.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ce2acf1108324b54d28f39c993c95