### PR TITLE
Add wide string support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 	CC ?= cc
 AR ?= ar
-CFLAGS ?= -Iinclude -Wall -Wextra -fPIC
+CFLAGS ?= -Iinclude -Wall -Wextra -fPIC -DVCURSES_WIDE
 BUILD := build
 LIB := libvcurses.a
 SRCS := src/vcurses.c src/init.c src/curses.c src/input.c src/keyname.c \

--- a/include/curses.h
+++ b/include/curses.h
@@ -78,6 +78,20 @@ int wgetstr(WINDOW *win, char *buf);
 int getstr(char *buf);
 int wgetnstr(WINDOW *win, char *buf, int n);
 int getnstr(char *buf, int n);
+#ifdef VCURSES_WIDE
+int waddwstr(WINDOW *win, const wchar_t *wstr);
+int waddnwstr(WINDOW *win, const wchar_t *wstr, int n);
+int addwstr(const wchar_t *wstr);
+int addnwstr(const wchar_t *wstr, int n);
+int mvwaddwstr(WINDOW *win,int y,int x,const wchar_t *wstr);
+int mvwaddnwstr(WINDOW *win,int y,int x,const wchar_t *wstr,int n);
+int mvaddwstr(int y,int x,const wchar_t *wstr);
+int mvaddnwstr(int y,int x,const wchar_t *wstr,int n);
+int wget_wstr(WINDOW *win, wchar_t *buf);
+int wgetn_wstr(WINDOW *win, wchar_t *buf, int n);
+int get_wstr(wchar_t *buf);
+int getn_wstr(wchar_t *buf, int n);
+#endif
 int wscanw(WINDOW *win, const char *fmt, ...);
 int scanw(const char *fmt, ...);
 int mvwscanw(WINDOW *win, int y, int x, const char *fmt, ...);

--- a/tests/input.c
+++ b/tests/input.c
@@ -105,6 +105,27 @@ START_TEST(test_getnstr_wrapper)
 }
 END_TEST
 
+#ifdef VCURSES_WIDE
+START_TEST(test_wgetn_wstr_limits_length)
+{
+    WINDOW *w = newwin(1,1,0,0);
+    unget_wch(L'\n');
+    unget_wch(L'c');
+    unget_wch(L'b');
+    unget_wch(L'a');
+    wchar_t buf[3];
+    ck_assert_int_eq(wgetn_wstr(w, buf, 2), 0);
+    ck_assert_int_eq(buf[0], L'a');
+    ck_assert_int_eq(buf[1], L'b');
+    ck_assert_int_eq(buf[2], L'\0');
+    nodelay(w, true);
+    wchar_t wc;
+    ck_assert_int_eq(wget_wch(w, &wc), -1);
+    delwin(w);
+}
+END_TEST
+#endif
+
 START_TEST(test_keypad_translates_backspace)
 {
     WINDOW *w = newwin(1,1,0,0);
@@ -200,6 +221,9 @@ Suite *input_suite(void)
     tcase_add_test(tc, test_resize_event);
     tcase_add_test(tc, test_wgetnstr_limits_length);
     tcase_add_test(tc, test_getnstr_wrapper);
+#ifdef VCURSES_WIDE
+    tcase_add_test(tc, test_wgetn_wstr_limits_length);
+#endif
     tcase_add_test(tc, test_keypad_translates_backspace);
     tcase_add_test(tc, test_keypad_translates_enter);
     tcase_add_test(tc, test_meta_masks_high_bit);

--- a/tests/pad.c
+++ b/tests/pad.c
@@ -34,12 +34,28 @@ START_TEST(test_prefresh_returns_zero)
 }
 END_TEST
 
+#ifdef VCURSES_WIDE
+START_TEST(test_waddwstr_pad)
+{
+    WINDOW *p = newpad(1,3);
+    wchar_t text[] = L"ab";
+    ck_assert_int_eq(waddwstr(p, text), 0);
+    ck_assert_int_eq(p->pad_buf[0][0], text[0]);
+    ck_assert_int_eq(p->pad_buf[0][1], text[1]);
+    delwin(p);
+}
+END_TEST
+#endif
+
 Suite *pad_suite(void)
 {
     Suite *s = suite_create("pad");
     TCase *tc = tcase_create("core");
     tcase_add_test(tc, test_newpad_basic);
     tcase_add_test(tc, test_subpad_offsets);
+#ifdef VCURSES_WIDE
+    tcase_add_test(tc, test_waddwstr_pad);
+#endif
     tcase_add_test(tc, test_prefresh_returns_zero);
     suite_add_tcase(s, tc);
     return s;


### PR DESCRIPTION
## Summary
- support wide string APIs when built with VCURSES_WIDE
- implement wide string output helpers
- implement wide string input helpers
- test pad wide string output and wgetn_wstr
- enable VCURSES_WIDE in build

## Testing
- `make`
- `make test` *(fails: Assertion errors in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_685e34f71ae083249fa75dc51a576fce